### PR TITLE
update Jensen-Shannon metric function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Distances.jl
 
+
 [![Build Status](https://travis-ci.org/JuliaStats/Distances.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/Distances.jl)
 
 A Julia package for evaluating distances(metrics) between vectors.
@@ -23,6 +24,7 @@ This package also provides optimized functions to compute column-wise and pairwi
 * Squared Mahalanobis distance
 * Bhattacharyya distance
 * Hellinger distance
+* Jensen-Shannon metric
 
 For ``Euclidean distance``, ``Squared Euclidean distance``, ``Cityblock distance``, ``Minkowski distance``, and ``Hamming distance``, a weighted version is also provided.
 
@@ -141,6 +143,7 @@ Each distance corresponds to a distance type. The type name and the correspondin
 |  WeightedCityblock   |  cityblock(x, y, w)      | sum(abs(x - y) .* w)  |
 |  WeightedMinkowski   |  minkowski(x, y, w, p)   | sum(abs(x - y).^p .* w) ^ (1/p)  |
 |  WeightedHamming     |  hamming(x, y, w)        | sum((x .!= y) .* w)  |
+|  JSMetric            |  js_metric(X)        | entropy(X ./ m) - sum(colwise(entropy,X)) / m|
   
 **Note:** The formulas above are using *Julia*'s functions. These formulas are mainly for conveying the math concepts in a concise way. The actual implementation may use a faster way.
 

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -40,6 +40,7 @@ export
     Mahalanobis,
     BhattacharyyaDist,
     HellingerDist,
+    JSMetric,
 
     # convenient functions
     euclidean,
@@ -65,7 +66,8 @@ export
     sqmahalanobis,
     mahalanobis,
     bhattacharyya,
-    hellinger
+    hellinger,
+    js_metric
 
 include("common.jl")
 include("generic.jl")
@@ -73,6 +75,7 @@ include("metrics.jl")
 include("wmetrics.jl")
 include("mahalanobis.jl")
 include("bhattacharyya.jl")
+include("jsmetric.jl")
 
 end # module end
 

--- a/src/jsmetric.jl
+++ b/src/jsmetric.jl
@@ -1,0 +1,30 @@
+# The square root of the Jensen–Shannon divergence is a metric ,it called Jensen Shannon metric.
+# Here is the Jensen-Shannon divergence of m discrete probability distributions (p^1, ...,p^m ): 
+# JSmetric(p^1,...,p^m)=H(\frac{p^1+...+p^m}{m})-\frac{\sum_{j=1}^{m} H(p^j)}{m} 
+# where  H() is entropy.
+# We can use this function to calculate multi-distributions JS divergence square root.
+
+type JSMetric <: Metric end
+
+# JS metric function
+ 
+ function evaluate(dist::JSMetric, a::AbstractArray)
+     (x, y) = size(a)
+     a_row = sum(a,2) / y
+     entropy_average = 0
+     for i = 1 : x
+       @inbounds a_rowi = a_row[i]
+       entropy_average += (a_rowi > 0 ? -1 * a_rowi * log(a_rowi) : 0)
+     end
+     average_entropy = 0
+     for i = 1 : x
+       for j = 1 : y
+         @inbounds aij = a[i,j]
+         average_entropy += (aij > 0 ? -1 * aij * log(aij) : 0)
+       end
+     end
+     jsd = ((entropy_average -  average_entropy / y) < 1.0e-16) ? 0 : (entropy_average -  average_entropy / y)
+     sqrt(jsd)
+ end
+ 
+ js_metric(a::AbstractArray) = evaluate(JSMetric(), a)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -139,6 +139,12 @@ expected_bc_p_q = sum(sqrt(pp .* pq))
 # Ensure it is semimetric
 @test_approx_eq_eps bhattacharyya(x, y) bhattacharyya(y, x) 1.0e-12
 
+# Jensen Shannon metric
+ 
+P = reshape([px,px,px],4,3)
+@test js_metric(P) == 0.0
+
+
 
 # test column-wise metrics
 


### PR DESCRIPTION
The square root of the Jensen–Shannon divergence is a metric. We can use it to calculate multi-distributions divergence. In bioinformatics field, we often use it to test isoform abundance changes among multiple expreiments in RNA-Seq data.

Here is the Jensen-Shannon divergence of m discrete probability distributions (p^1, ...,p^m ):

![img](http://www.sciweavers.org/tex2img.php?eq=JSmetric%28p%5E1%2C...%2Cp%5Em%29%3DH%28%5Cfrac%7Bp%5E1%2B...%2Bp%5Em%7D%7Bm%7D%29-%5Cfrac%7B%5Csum_%7Bj%3D1%7D%5E%7Bm%7D%20H%28p%5Ej%29%7D%7Bm%7D&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0)

where H() is entropy.