### PR TITLE
Fix potentially negative distances in SqEuclidean pairwise!

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -61,7 +61,8 @@ function pdist!(r, sa2, sb2)
     for j = 1 : size(r,2)
         sb = sb2[j]
         @simd for i = 1 : size(r,1)
-            @inbounds r[i,j] = sa2[i] + sb - 2 * r[i,j]
+            @inbounds v = sa2[i] + sb - 2 * r[i,j]
+            @inbounds r[i,j] = isnan(v) ? NaN : max(v, 0.)
         end
     end
     r
@@ -77,7 +78,8 @@ function pairwise!(r::AbstractMatrix, dist::SqEuclidean, a::AbstractMatrix)
         end
         @inbounds r[j,j] = 0
         for i = j+1 : n
-            @inbounds r[i,j] = sa2[i] + sa2[j] - 2 * r[i,j]
+            @inbounds v = sa2[i] + sa2[j] - 2 * r[i,j]
+            @inbounds r[i,j] = isnan(v) ? NaN : max(v, 0.)
         end
     end
     r


### PR DESCRIPTION
I'm calculating the pairwise square-euclidean distance on a transposed 1-dimensional array that is the result of some earlier steps (that is, the array is generated by Julia). The `pairwise` family of functions for `SqEuclidean` are generating negative values for me. To replicate (the array `a` is the output of the `repr` command in my Julia session, hence the high accuracy...):

```
julia> using Distances

julia> a = [8.702377585093074e-17 0.3388749348239833 -0.1983502059414518 -0.5835590551525691 0.0 0.0 -0.5835590551525691 -0.19835020594145175 0.10128149246701958 0.007090677971622002 0.007090677971622002 0.33887493482398334 0.0 0.007090677971622002 0.0 0.0 0.0 0.007090677971622002 0.007090677971622002 0.007090677971622002];

julia> b = pairwise(SqEuclidean(), a);

julia> b[2, 12]
-2.7755575615628914e-17

julia> b[3, 8]
-1.3877787807814457e-17

julia> c = pairwise(Euclidean(), a);

julia> c[2, 12]
0.0

julia> c[3, 8]
0.0

julia> d = pairwise(Euclidean(), a) .* pairwise(Euclidean(), a);

julia> d[2, 12]
0.0

julia> d[3, 8]
0.0
```

So, only `SqEuclidean` produces negative values. If you use `Euclidean`, the distances produced are 0.0 (so, obviously squaring it also results  in 0.0).

If you look, the pairs that cause the problem are equivalent up to a high accuracy, but not exactly equivalent.

It looks like you can fix it by taking a similar strategy to `Euclidean`, as implemented in this pull request.
