### PR TITLE
Return Nan if some element equals NaN

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -142,13 +142,16 @@ cityblock{T <: Number}(a::T, b::T) = evaluate(Cityblock(), a, b)
 function evaluate(dist::Chebyshev, a::AbstractVector, b::AbstractVector)
     n = get_common_len(a, b)
     s = 0.
-    for i = 1:n
-        @inbounds ai = abs(a[i] - b[i])
-        if ai > s
+    @inbounds for i = 1:n
+        ai = abs(a[i] - b[i])
+        if isnan(ai)
+            s = NaN
+            break
+        elseif ai > s
             s = ai
         end
     end
-    s
+    return s
 end
 chebyshev(a::AbstractVector, b::AbstractVector) = evaluate(Chebyshev(), a, b)
 evaluate{T <: Number}(dist::Chebyshev, a::T, b::T) = abs(a-b)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -265,3 +265,23 @@ Q = Q * Q'  # make sure Q is positive-definite
 @test_pairwise SqMahalanobis(Q) X Y 1.0e-13
 @test_pairwise Mahalanobis(Q) X Y 1.0e-13
 
+
+
+# test NaN
+a = 1.0
+b = NaN
+@test isnan(sqeuclidean(a, b))
+@test isnan(euclidean(a, b))
+@test isnan(cityblock(a, b))
+@test isnan(chebyshev(a, b))
+@test isnan(minkowski(a, b, 2))
+@test hamming(a, b) == 1
+
+a = [1.0]
+b = [NaN]
+@test isnan(sqeuclidean(a, b))
+@test isnan(euclidean(a, b))
+@test isnan(cityblock(a, b))
+@test isnan(chebyshev(a, b))
+@test isnan(minkowski(a, b, 2))
+@test hamming(a, b) == 1


### PR DESCRIPTION
Currently, we have

```julia
x = fill(1.0, 10)
y = fill(NaN, 10)
chebyshev(x, y)
# 0.0
```

With this pull request, it returns NaN.