### PR TITLE
Allow Abstract Arrays

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -6,18 +6,6 @@
 #
 ###########################################################
 
-function get_common_len(a::AbstractVector, b::AbstractVector)
-    n = length(a)
-    length(b) == n || throw(DimensionMismatch("The lengths of a and b must match."))
-    return n
-end
-
-function get_common_len(a::AbstractVector, b::AbstractVector, c::AbstractVector)
-    n = length(a)
-    length(b) == length(c) == n || throw(DimensionMismatch("The lengths of a and b must match."))
-    return n
-end
-
 function get_common_ncols(a::AbstractMatrix, b::AbstractMatrix)
     na = size(a, 2)
     size(b, 2) == na || throw(DimensionMismatch("The number of columns in a and b must match."))


### PR DESCRIPTION
The goal of this pull request is to allow AbstractArrays rather than just AbstractVectors in `metrics` and `wmetrics`. To allow this, I follow a recent pull request by @timholy  in Base #13460.

Since the loop is slightly more verbose, I ended up refractoring the code. There is no supplementary allocation compared to the current situation (i.e. @time macro gives the same allocation).

Moreover, I did two changes:
- Chebyshev now relies on the `max` function. If `max(0, NaN)` were to be changed to `NaN` at some point in Base, this will directly pass through.
- Type instability in  `JSDivergence` is suppressed

Now I'm unclear on something. While some norms are initiated to `zero(eltype(a))`, most of the distances are intiated to 0.0. I'm not sure why. Should not `chebyshev([1, 3], [1, 4])` return an `Int`? This also creates some inconsistency within norms wrt vectors vs numbers: `Evaluate(SqEuclidean, [1], [3])` is a Float but `Evaluate(SqEuclidean, 1, 3)` is not. 