### PR TITLE
Add back @simd to evaluate

### DIFF
--- a/src/bhattacharyya.jl
+++ b/src/bhattacharyya.jl
@@ -16,7 +16,7 @@ function bhattacharyya_coeff{T<:Number}(a::AbstractVector{T}, b::AbstractVector{
     asum = zero(T)
     bsum = zero(T)
 
-    for i = 1:n
+    @simd for i = 1:n
         @inbounds ai = a[i]
         @inbounds bi = b[i]
         sqab += sqrt(ai * bi)
@@ -24,7 +24,7 @@ function bhattacharyya_coeff{T<:Number}(a::AbstractVector{T}, b::AbstractVector{
         bsum += bi
     end
 
-    sqab / sqrt(asum * bsum) 
+    sqab / sqrt(asum * bsum)
 end
 
 bhattacharyya_coeff{T <: Number}(a::T, b::T) = throw("Bhattacharyya coefficient cannot be calculated for scalars")

--- a/src/common.jl
+++ b/src/common.jl
@@ -19,14 +19,14 @@ function get_colwise_dims(r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix
 end
 
 function get_colwise_dims(r::AbstractArray, a::AbstractVector, b::AbstractMatrix)
-    length(a) == size(b, 1) || 
+    length(a) == size(b, 1) ||
         throw(DimensionMismatch("The length of a must match the number of rows in b."))
     length(r) == size(b, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(b)
 end
 
 function get_colwise_dims(r::AbstractArray, a::AbstractMatrix, b::AbstractVector)
-    size(a, 1) == length(b) || 
+    size(a, 1) == length(b) ||
         throw(DimensionMismatch("The length of b must match the number of rows in a."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
@@ -57,7 +57,7 @@ function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractMatrix, b::Abstra
 end
 
 function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractVector, b::AbstractMatrix)
-    length(a) == size(b, 1) == d || 
+    length(a) == size(b, 1) == d ||
         throw(DimensionMismatch("Incorrect vector dimensions."))
     length(r) == size(b, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(b)
@@ -91,8 +91,8 @@ end
 #
 ###########################################################
 
-function sqrt!(a::Array)
-    for i = 1:length(a)
+function sqrt!(a::AbstractArray)
+    @simd for i in eachindex(a)
         @inbounds a[i] = sqrt(a[i])
     end
     a
@@ -127,7 +127,7 @@ end
 function dot_percol!(r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
     m = size(a,1)
     n = size(a,2)
-    size(b) == (m,n) && length(r) == n || 
+    size(b) == (m,n) && length(r) == n ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     for j = 1:n
         aj = view(a,:,j)

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -47,8 +47,8 @@ function pairwise!{T<:AbstractFloat}(r::AbstractMatrix, dist::SqMahalanobis{T}, 
     At_mul_B!(r, a, Qb)
 
     for j = 1 : nb
-        for i = 1 : na
-            r[i,j] = sa2[i] + sb2[j] - 2 * r[i,j]
+        @simd for i = 1 : na
+            @inbounds r[i,j] = sa2[i] + sb2[j] - 2 * r[i,j]
         end
     end
     r
@@ -64,11 +64,11 @@ function pairwise!{T<:AbstractFloat}(r::AbstractMatrix, dist::SqMahalanobis{T}, 
 
     for j = 1 : n
         for i = 1 : j-1
-            r[i,j] = r[j,i]
+            @inbounds r[i,j] = r[j,i]
         end
         r[j,j] = 0
         for i = j+1 : n
-            r[i,j] = sa2[i] + sa2[j] - 2 * r[i,j]
+            @inbounds r[i,j] = sa2[i] + sa2[j] - 2 * r[i,j]
         end
     end
     r

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -247,7 +247,7 @@ function pairwise!(r::AbstractMatrix, dist::CosineDist, a::AbstractMatrix, b::Ab
     ra = sqrt!(sumsq_percol(a))
     rb = sqrt!(sumsq_percol(b))
     for j = 1 : nb
-        for i = 1 : na
+        @simd for i = 1 : na
             @inbounds r[i,j] = max(1 - r[i,j] / (ra[i] * rb[j]), 0)
         end
     end
@@ -258,7 +258,7 @@ function pairwise!(r::AbstractMatrix, dist::CosineDist, a::AbstractMatrix)
     At_mul_B!(r, a, a)
     ra = sqrt!(sumsq_percol(a))
     for j = 1 : n
-        for i = j+1 : n
+        @simd for i = j+1 : n
             @inbounds r[i,j] = max(1 - r[i,j] / (ra[i] * ra[j]), 0)
         end
         @inbounds r[j,j] = 0

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -47,7 +47,7 @@ function evaluate(d::UnionMetrics, a::AbstractArray, b::AbstractArray)
     end
     s = eval_start(d, a, b)
     if size(a) == size(b)
-        for I in eachindex(a, b)
+        @simd for I in eachindex(a, b)
             @inbounds ai = a[I]
             @inbounds bi = b[I]
             s = eval_reduce(d, s, eval_op(d, ai, bi))
@@ -58,12 +58,12 @@ function evaluate(d::UnionMetrics, a::AbstractArray, b::AbstractArray)
             @inbounds bi = b[Ib]
             s = eval_reduce(d, s, eval_op(d, ai, bi))
         end
-    end    
+    end
     return eval_end(d, s)
 end
-result_type{T1, T2}(dist::UnionMetrics, ::AbstractArray{T1}, ::AbstractArray{T2}) = 
+result_type{T1, T2}(dist::UnionMetrics, ::AbstractArray{T1}, ::AbstractArray{T2}) =
     typeof(eval_end(dist, eval_op(dist, one(T1), one(T2))))
-eval_start(d::UnionMetrics, a::AbstractArray, b::AbstractArray) = 
+eval_start(d::UnionMetrics, a::AbstractArray, b::AbstractArray) =
     zero(result_type(d, a, b))
 eval_end(d::UnionMetrics, s) = s
 
@@ -142,7 +142,7 @@ chisq_dist(a::AbstractArray, b::AbstractArray) = evaluate(ChiSqDist(), a, b)
 kl_divergence(a::AbstractArray, b::AbstractArray) = evaluate(KLDivergence(), a, b)
 
 # JSDivergence
-@compat @inline function eval_op{T}(::JSDivergence, ai::T, bi::T) 
+@compat @inline function eval_op{T}(::JSDivergence, ai::T, bi::T)
     u = (ai + bi) / 2
     ta = ai > 0 ? ai * log(ai) / 2 : zero(log(one(T)))
     tb = bi > 0 ? bi * log(bi) / 2 : zero(log(one(T)))

--- a/src/wmetrics.jl
+++ b/src/wmetrics.jl
@@ -77,7 +77,7 @@ function evaluate(d::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray)
             @inbounds wi = d.weights[Iw]
             s = eval_reduce(d, s, eval_op(d, ai, bi, wi))
         end
-    end    
+    end
     return eval_end(d, s)
 end
 
@@ -123,7 +123,7 @@ function pairwise!(r::AbstractMatrix, dist::WeightedSqEuclidean, a::AbstractMatr
     sb2 = wsumsq_percol(w, b)
     At_mul_B!(r, a, b .* w)
     for j = 1 : nb
-        for i = 1 : na
+        @simd for i = 1 : na
             @inbounds r[i,j] = sa2[i] + sb2[j] - 2 * r[i,j]
         end
     end
@@ -141,7 +141,7 @@ function pairwise!(r::AbstractMatrix, dist::WeightedSqEuclidean, a::AbstractMatr
             @inbounds r[i,j] = r[j,i]
         end
         @inbounds r[j,j] = 0
-        for i = j+1 : n
+        @simd for i = j+1 : n
             @inbounds r[i,j] = sa2[i] + sa2[j] - 2 * r[i,j]
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ tests = ["dists"]
 println("Running tests ...")
 
 for t in tests
-	fn = "test_$t.jl"
-	println("* $fn ...")
-	include(fn)
+    fn = "test_$t.jl"
+    println("* $fn ...")
+    include(fn)
 end

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -39,7 +39,7 @@ p[p .< 0.3] = 0.
 q = rand(12)
 a = [1., 2., 1., 3., 2., 1.]
 b = [1., 3., 0., 2., 2., 0.]
-for (x, y) in (([4., 5., 6., 7.], [3., 9., 8., 1.]), 
+for (x, y) in (([4., 5., 6., 7.], [3., 9., 8., 1.]),
                 ([4., 5., 6., 7.], [3. 8.; 9. 1.]))
     @test sqeuclidean(x, x) == 0.
     @test sqeuclidean(x, y) == 57.
@@ -108,12 +108,12 @@ for (x, y) in (([4., 5., 6., 7.], [3., 9., 8., 1.]),
     @test whamming(a, a, w) == 0.
     @test whamming(a, b, w) == sum((a .!= b) .* w)
 
-  
+
 end
 
 
 
-# test NaN behavior 
+# test NaN behavior
 a = [NaN, 0]; b = [0, NaN]
 @test isnan(chebyshev(a, b)) == isnan(maximum(a-b))
 a = [NaN, 0]; b = [0, 1]
@@ -134,19 +134,19 @@ b = Float64[]
 @test minkowski(a, b, 2) == 0.
 @test isa(minkowski(a, b, 2), Float64)
 @test hamming(a, b) == 0.0
-@test isa(hamming(a, b), Int) 
+@test isa(hamming(a, b), Int)
 
 w = Float64[]
-@test isa(whamming(a, b, w), Float64) 
+@test isa(whamming(a, b, w), Float64)
 
 
 
 a = [1, 0]; b = [2]
-@test_throws DimensionMismatch sqeuclidean(a, b) 
+@test_throws DimensionMismatch sqeuclidean(a, b)
 a = [1, 0]; b = [2.0] ; w = [3.0]
-@test_throws DimensionMismatch wsqeuclidean(a, b, w) 
+@test_throws DimensionMismatch wsqeuclidean(a, b, w)
 a = [1, 0]; b = [2.0, 4.0] ; w = [3.0]
-@test_throws DimensionMismatch wsqeuclidean(a, b, w) 
+@test_throws DimensionMismatch wsqeuclidean(a, b, w)
 
 
 


### PR DESCRIPTION
This dissapeared in the latest refactoring and makes a big difference.

With

```jl
function test()
    a = rand(100)
    b = rand(100)
    E = Euclidean()
    @time for i = 1:10^7
        evaluate(E, a, b)
    end
end

function test32()
    a = rand(Float32, 100)
    b = rand(Float32, 100)
    E = Euclidean()
    @time for i = 1:10^7
        evaluate(E, a, b)
    end
end
```

I get on master:

```jl
julia> test32()
  0.823266 seconds

julia> test()
  0.801979 seconds
```

and with PR:

```jl
julia> test()
  0.409450 seconds

julia> test32()
  0.261282 seconds
```
