### PR TITLE
unify the result_type method

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -24,7 +24,7 @@ abstract Metric <: SemiMetric
 
 # Generic functions
 
-result_type(::PreMetric, T1::Type, T2::Type) = Float64
+result_type(::PreMetric, ::AbstractArray, ::AbstractArray) = Float64
 
 
 # Generic column-wise evaluation
@@ -62,19 +62,19 @@ end
 
 function colwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix)
     n = get_common_ncols(a, b)
-    r = Array(result_type(metric, eltype(a), eltype(b)), n)
+    r = Array(result_type(metric, a, b), n)
     colwise!(r, metric, a, b)
 end
 
 function colwise(metric::PreMetric, a::AbstractVector, b::AbstractMatrix)
     n = size(b, 2)
-    r = Array(result_type(metric, eltype(a), eltype(b)), n)
+    r = Array(result_type(metric, a, b), n)
     colwise!(r, metric, a, b)
 end
 
 function colwise(metric::PreMetric, a::AbstractMatrix, b::AbstractVector)
     n = size(a, 2)
-    r = Array(result_type(metric, eltype(a), eltype(b)), n)
+    r = Array(result_type(metric, a, b), n)
     colwise!(r, metric, a, b)
 end
 
@@ -117,19 +117,19 @@ end
 function pairwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix)
     m = size(a, 2)
     n = size(b, 2)
-    r = Array(result_type(metric, eltype(a), eltype(b)), (m, n))
+    r = Array(result_type(metric, a, b), (m, n))
     pairwise!(r, metric, a, b)
 end
 
 function pairwise(metric::PreMetric, a::AbstractMatrix)
     n = size(a, 2)
-    r = Array(result_type(metric, eltype(a), eltype(a)), (n, n))
+    r = Array(result_type(metric, a, a), (n, n))
     pairwise!(r, metric, a)
 end
 
 function pairwise(metric::SemiMetric, a::AbstractMatrix)
     n = size(a, 2)
-    r = Array(result_type(metric, eltype(a), eltype(a)), (n, n))
+    r = Array(result_type(metric, a, a), (n, n))
     pairwise!(r, metric, a)
 end
 

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -8,8 +8,8 @@ type SqMahalanobis{T} <: SemiMetric
     qmat::Matrix{T}
 end
 
-result_type{T}(::Mahalanobis{T}, T1::Type, T2::Type) = T
-result_type{T}(::SqMahalanobis{T}, T1::Type, T2::Type) = T
+result_type{T}(::Mahalanobis{T}, ::AbstractArray, ::AbstractArray) = T
+result_type{T}(::SqMahalanobis{T}, ::AbstractArray, ::AbstractArray) = T
 
 # SqMahalanobis
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -130,6 +130,7 @@ cosine_dist(a::AbstractArray, b::AbstractArray) = evaluate(CosineDist(), a, b)
 _centralize(x::AbstractArray) = x .- mean(x)
 evaluate(::CorrDist, a::AbstractArray, b::AbstractArray) = cosine_dist(_centralize(a), _centralize(b))
 corr_dist(a::AbstractArray, b::AbstractArray) = evaluate(CorrDist(), a, b)
+result_type(::CorrDist, a::AbstractArray, b::AbstractArray) = result_type(CosineDist(), a, b)
 
 # ChiSqDist
 @compat @inline eval_op(::ChiSqDist, ai, bi) = abs2(ai - bi) / (ai + bi)
@@ -166,9 +167,12 @@ end
     end
     return min_d, max_d
 end
+
 eval_end(::SpanNormDist, s) = s[2] - s[1]
 spannorm_dist(a::AbstractArray, b::AbstractArray) = evaluate(SpanNormDist(), a, b)
-result_type(dist::SpanNormDist, T1::Type, T2::Type) = typeof(eval_op(dist, one(T1), one(T2)))
+function result_type{T1, T2}(dist::SpanNormDist, ::AbstractArray{T1}, ::AbstractArray{T2})
+    typeof(eval_op(dist, one(T1), one(T2)))
+end
 
 
 ###########################################################


### PR DESCRIPTION
Ref #28, fixes #28

Problem was that the `result_type` in `generic` had different signatures than the ones in `metric` so the specialized `result_types` were never used when `pairwise` was used. This unifies the `result_type` signatures.

Benchmark:

```jl
N = 10000;
dim = 25;
data = rand(Float32, dim, N);
query = rand(Float32, dim, N);

# Master
julia> @time pairwise(SqEuclidean(), data, query);
  2.435364 seconds (37 allocations: 763.017 MB, 0.34% gc time)

# PR
julia> @time pairwise(SqEuclidean(), data, query);
  0.222634 seconds (31 allocations: 381.547 MB, 0.88% gc time)
```

