### PR TITLE
Add a precision threshold to Euclidean

### DIFF
--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -103,7 +103,7 @@ w = rand(size(a))
 p = r = rand(12)
 p[p .< 0.3] = 0.0
 scale = sum(p) / sum(r)
-r /= sum(r)    
+r /= sum(r)
 p /= sum(p)
 q = rand(12)
 q /= sum(q)
@@ -121,14 +121,14 @@ end
 @test renyi_divergence(p, p, rand()) ≈ 0
 @test renyi_divergence(p, p, 1.0 + rand()) ≈ 0
 @test renyi_divergence(p, p, Inf) ≈ 0
-@test renyi_divergence(p, r, 0) ≈ -log(scale)    
-@test renyi_divergence(p, r, 1) ≈ -log(scale)    
-@test renyi_divergence(p, r, rand()) ≈ -log(scale)    
+@test renyi_divergence(p, r, 0) ≈ -log(scale)
+@test renyi_divergence(p, r, 1) ≈ -log(scale)
+@test renyi_divergence(p, r, rand()) ≈ -log(scale)
 @test renyi_divergence(p, r, Inf) ≈ -log(scale)
 @test isinf(renyi_divergence([0.0, 0.5, 0.5], [0.0, 1.0, 0.0], Inf))
 @test renyi_divergence([0.0, 1.0, 0.0], [0.0, 0.5, 0.5], Inf) ≈ log(2.0)
 @test renyi_divergence(p, q, 1) ≈ kl_divergence(p, q)
-    
+
 pm = (p + q) / 2
 jsv = kl_divergence(p, pm) / 2 + kl_divergence(q, pm) / 2
 @test js_divergence(p, p) ≈ 0.0
@@ -385,3 +385,19 @@ Q = Q * Q'  # make sure Q is positive-definite
 @test_pairwise Mahalanobis(Q) X Y
 
 end #testset
+
+@testset "Euclidean precision" begin
+    X = [0.1 0.2; 0.3 0.4; -0.1 -0.1]
+    pd = pairwise(Euclidean(1e-12), X, X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
+    pd = pairwise(Euclidean(1e-12), X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
+    pd = pairwise(SqEuclidean(1e-12), X, X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
+    pd = pairwise(SqEuclidean(1e-12), X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
+end


### PR DESCRIPTION
On master we have this:
```julia
julia> using Distances

julia> X = [0.1 0.2; 0.3 0.4; -0.1 -0.1]
3×2 Array{Float64,2}:
  0.1   0.2
  0.3   0.4
 -0.1  -0.1

julia> pd = pairwise(Euclidean(), X, X)
2×2 Array{Float64,2}:
 7.45058e-9  0.141421
 0.141421    0.0     
```
Obviously the diagonal entries of `pd` should be 0. Here it's not because of the strategy (chosen for efficiency) to calculate dot products and then compute the square-distance by `sa + sb - 2*r`. This PR recalculates the distance by `\sum (ai-bi)^2` when the gap between the points is below some threshold. It should be non-breaking, because the fallback threshold is 0.
