### PR TITLE
Tests for correct Pre/Semi/Metric subtyping

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
 
 The implementation has been carefully optimized based on benchmarks. The Julia scripts ``test/bench_colwise.jl`` and ``test/bench_pairwise.jl`` run the benchmarks on a variety of distances, respectively under column-wise and pairwise settings.
 
-Here are benchmarks obtained on Linux with Intel Core i7-4770K 3.5 GHz.
+Here are benchmarks obtained running Julia 0.5.1 on a late-2016 MacBook Pro running MacOS 10.12.3 with an quad-core Intel Core i7 processor @ 2.9 GHz.
 
 #### Column-wise benchmark
 
@@ -193,28 +193,32 @@ The table below compares the performance (measured in terms of average elapsed t
 
 |  distance  |  loop  |  colwise  |  gain  |
 |----------- | -------| ----------| -------|
-| SqEuclidean | 0.012308s |  0.003860s |  3.1884 |
-| Euclidean | 0.012484s |  0.003995s |  3.1246 |
-| Cityblock | 0.012463s |  0.003927s |  3.1735 |
-| Chebyshev | 0.014897s |  0.005898s |  2.5258 |
-| Minkowski | 0.028154s |  0.017812s |  1.5806 |
-| Hamming | 0.012200s |  0.003896s |  3.1317 |
-| CosineDist | 0.013816s |  0.004670s |  2.9583 |
-| CorrDist | 0.023349s |  0.016626s |  1.4044 |
-| ChiSqDist | 0.015375s |  0.004788s |  3.2109 |
-| KLDivergence | 0.044360s |  0.036123s |  1.2280 |
-| JSDivergence | 0.098587s |  0.085595s |  1.1518 |
-| BhattacharyyaDist | 0.023103s |  0.013002s |  1.7769 |
-| HellingerDist | 0.023329s |  0.012555s |  1.8581 |
-| WeightedSqEuclidean | 0.012136s |  0.003758s |  3.2296 |
-| WeightedEuclidean | 0.012307s |  0.003789s |  3.2482 |
-| WeightedCityblock | 0.012287s |  0.003923s |  3.1321 |
-| WeightedMinkowski | 0.029895s |  0.018471s |  1.6185 |
-| WeightedHamming | 0.013427s |  0.004082s |  3.2896 |
-| SqMahalanobis | 0.121636s |  0.019370s |  6.2796 |
-| Mahalanobis | 0.117871s |  0.019939s |  5.9117 |
+| SqEuclidean | 0.007464s |  0.001993s |  3.7459 |
+| Euclidean | 0.007294s |  0.002035s |  3.5840 |
+| Cityblock | 0.007411s |  0.001991s |  3.7231 |
+| Chebyshev | 0.011455s |  0.005540s |  2.0678 |
+| Minkowski | 0.023713s |  0.016705s |  1.4195 |
+| Hamming | 0.006996s |  0.001985s |  3.5250 |
+| CosineDist | 0.008863s |  0.003301s |  2.6850 |
+| CorrDist | 0.014315s |  0.016693s |  0.8575 |
+| ChiSqDist | 0.008136s |  0.002109s |  3.8578 |
+| KLDivergence | 0.035595s |  0.032610s |  1.0916 |
+| RenyiDivergence(0) | 0.014064s |  0.009562s |  1.4707 |
+| RenyiDivergence(1) | 0.042286s |  0.039520s |  1.0700 |
+| RenyiDivergence(2) | 0.017232s |  0.013540s |  1.2727 |
+| RenyiDivergence(∞) | 0.015273s |  0.010613s |  1.4391 |
+| JSDivergence | 0.085558s |  0.075936s |  1.1267 |
+| BhattacharyyaDist | 0.009933s |  0.004510s |  2.2023 |
+| HellingerDist | 0.010375s |  0.003817s |  2.7184 |
+| WeightedSqEuclidean | 0.007462s |  0.002019s |  3.6957 |
+| WeightedEuclidean | 0.007483s |  0.002075s |  3.6067 |
+| WeightedCityblock | 0.007437s |  0.002034s |  3.6563 |
+| WeightedMinkowski | 0.023364s |  0.017775s |  1.3144 |
+| WeightedHamming | 0.009027s |  0.002754s |  3.2776 |
+| SqMahalanobis | 0.103410s |  0.032976s |  3.1359 |
+| Mahalanobis | 0.104362s |  0.033305s |  3.1336 |
 
-We can see that using ``colwise`` instead of a simple loop yields considerable gain (2x - 6x), especially when the internal computation of each distance is simple. Nonetheless, when the computaton of a single distance is heavy enough (e.g. *Minkowski* and *JSDivergence*), the gain is not as significant.
+We can see that using ``colwise`` instead of a simple loop yields considerable gain (2x - 4x), especially when the internal computation of each distance is simple. Nonetheless, when the computation of a single distance is heavy enough (e.g. *KLDivergence*,  *RenyiDivergence*), the gain is not as significant.
 
 #### Pairwise benchmark
 
@@ -222,25 +226,29 @@ The table below compares the performance (measured in terms of average elapsed t
 
 |  distance  |  loop  |  pairwise |  gain  |
 |----------- | -------| ----------| -------|
-| SqEuclidean | 0.032179s |  0.000170s | **189.7468** |
-| Euclidean | 0.031646s |  0.000326s | **97.1773** |
-| Cityblock | 0.031594s |  0.002771s | 11.4032 |
-| Chebyshev | 0.036732s |  0.011575s |  3.1735 |
-| Minkowski | 0.073685s |  0.047725s |  1.5440 |
-| Hamming | 0.030016s |  0.002539s | 11.8236 |
-| CosineDist | 0.035426s |  0.000235s | **150.8504** |
-| CorrDist | 0.061430s |  0.000341s | **180.1693** |
-| ChiSqDist | 0.037702s |  0.011709s |  3.2199 |
-| KLDivergence | 0.119043s |  0.086861s |  1.3705 |
-| JSDivergence | 0.255449s |  0.227079s |  1.1249 |
-| BhattacharyyaDist | 0.059165s |  0.033330s |  1.7751 |
-| HellingerDist | 0.056953s |  0.031163s |  1.8276 |
-| WeightedSqEuclidean | 0.031781s |  0.000218s | **145.9820** |
-| WeightedEuclidean | 0.031365s |  0.000410s | **76.4517** |
-| WeightedCityblock | 0.031239s |  0.003242s |  9.6360 |
-| WeightedMinkowski | 0.077039s |  0.049319s |  1.5621 |
-| WeightedHamming | 0.032584s |  0.005673s |  5.7442 |
-| SqMahalanobis | 0.280485s |  0.000297s | **943.6018** |
-| Mahalanobis | 0.295715s |  0.000498s | **593.6096** |
+| SqEuclidean | 0.022127s |  0.000145s | **152.1941** |
+| Euclidean | 0.021477s |  0.000844s | **25.4365** |
+| Cityblock | 0.021622s |  0.004129s |  5.2366 |
+| Chebyshev | 0.033059s |  0.015156s |  2.1813 |
+| Minkowski | 0.063735s |  0.046181s |  1.3801 |
+| Hamming | 0.020737s |  0.003304s |  6.2757 |
+| CosineDist | 0.025623s |  0.000831s | **30.8470** |
+| CorrDist | 0.035662s |  0.000888s | **40.1586** |
+| ChiSqDist | 0.021997s |  0.004236s |  5.1928 |
+| KLDivergence | 0.094585s |  0.083738s |  1.1295 |
+| RenyiDivergence(0) | 0.041105s |  0.022306s |  1.8428 |
+| RenyiDivergence(1) | 0.112891s |  0.100909s |  1.1187 |
+| RenyiDivergence(2) | 0.048346s |  0.031279s |  1.5456 |
+| RenyiDivergence(∞) | 0.042273s |  0.026941s |  1.5691 |
+| JSDivergence | 0.203695s |  0.195379s |  1.0426 |
+| BhattacharyyaDist | 0.029058s |  0.010801s |  2.6904 |
+| HellingerDist | 0.027940s |  0.009818s |  2.8458 |
+| WeightedSqEuclidean | 0.022282s |  0.000173s | **128.5042** |
+| WeightedEuclidean | 0.022500s |  0.000268s | **84.1009** |
+| WeightedCityblock | 0.022641s |  0.004501s |  5.0296 |
+| WeightedMinkowski | 0.066117s |  0.047862s |  1.3814 |
+| WeightedHamming | 0.027153s |  0.007034s |  3.8601 |
+| SqMahalanobis | 0.338031s |  0.000863s | **391.9013** |
+| Mahalanobis | 0.341765s |  0.000953s | **358.5008** |
 
 For distances of which a major part of the computation is a quadratic form (e.g. *Euclidean*, *CosineDist*, *Mahalanobis*), the performance can be drastically improved by restructuring the computation and delegating the core part to ``GEMM`` in *BLAS*. The use of this strategy can easily lead to 100x performance gain over simple loops (see the highlighted part of the table above).

--- a/README.md
+++ b/README.md
@@ -193,30 +193,30 @@ The table below compares the performance (measured in terms of average elapsed t
 
 |  distance  |  loop  |  colwise  |  gain  |
 |----------- | -------| ----------| -------|
-| SqEuclidean | 0.007464s |  0.001993s |  3.7459 |
-| Euclidean | 0.007294s |  0.002035s |  3.5840 |
-| Cityblock | 0.007411s |  0.001991s |  3.7231 |
-| Chebyshev | 0.011455s |  0.005540s |  2.0678 |
-| Minkowski | 0.023713s |  0.016705s |  1.4195 |
-| Hamming | 0.006996s |  0.001985s |  3.5250 |
-| CosineDist | 0.008863s |  0.003301s |  2.6850 |
-| CorrDist | 0.014315s |  0.016693s |  0.8575 |
-| ChiSqDist | 0.008136s |  0.002109s |  3.8578 |
-| KLDivergence | 0.035595s |  0.032610s |  1.0916 |
-| RenyiDivergence(0) | 0.014064s |  0.009562s |  1.4707 |
-| RenyiDivergence(1) | 0.042286s |  0.039520s |  1.0700 |
-| RenyiDivergence(2) | 0.017232s |  0.013540s |  1.2727 |
-| RenyiDivergence(∞) | 0.015273s |  0.010613s |  1.4391 |
-| JSDivergence | 0.085558s |  0.075936s |  1.1267 |
-| BhattacharyyaDist | 0.009933s |  0.004510s |  2.2023 |
-| HellingerDist | 0.010375s |  0.003817s |  2.7184 |
-| WeightedSqEuclidean | 0.007462s |  0.002019s |  3.6957 |
-| WeightedEuclidean | 0.007483s |  0.002075s |  3.6067 |
-| WeightedCityblock | 0.007437s |  0.002034s |  3.6563 |
-| WeightedMinkowski | 0.023364s |  0.017775s |  1.3144 |
-| WeightedHamming | 0.009027s |  0.002754s |  3.2776 |
-| SqMahalanobis | 0.103410s |  0.032976s |  3.1359 |
-| Mahalanobis | 0.104362s |  0.033305s |  3.1336 |
+| SqEuclidean | 0.007267s |  0.002000s |  3.6334 |
+| Euclidean | 0.007471s |  0.002042s |  3.6584 |
+| Cityblock | 0.007239s |  0.001980s |  3.6556 |
+| Chebyshev | 0.011396s |  0.005274s |  2.1606 |
+| Minkowski | 0.022127s |  0.017161s |  1.2894 |
+| Hamming | 0.006777s |  0.001841s |  3.6804 |
+| CosineDist | 0.008709s |  0.003046s |  2.8592 |
+| CorrDist | 0.012766s |  0.014199s |  0.8991 |
+| ChiSqDist | 0.007321s |  0.002042s |  3.5856 |
+| KLDivergence | 0.037239s |  0.033535s |  1.1105 |
+| RenyiDivergence(0) | 0.014607s |  0.009587s |  1.5237 |
+| RenyiDivergence(1) | 0.044142s |  0.040953s |  1.0779 |
+| RenyiDivergence(2) | 0.019056s |  0.012029s |  1.5842 |
+| RenyiDivergence(∞) | 0.014469s |  0.010906s |  1.3267 |
+| JSDivergence | 0.077435s |  0.081599s |  0.9490 |
+| BhattacharyyaDist | 0.009805s |  0.004355s |  2.2514 |
+| HellingerDist | 0.010007s |  0.004030s |  2.4832 |
+| WeightedSqEuclidean | 0.007435s |  0.002051s |  3.6254 |
+| WeightedEuclidean | 0.008217s |  0.002075s |  3.9591 |
+| WeightedCityblock | 0.007486s |  0.002058s |  3.6378 |
+| WeightedMinkowski | 0.024653s |  0.019632s |  1.2557 |
+| WeightedHamming | 0.008467s |  0.002962s |  2.8587 |
+| SqMahalanobis | 0.101976s |  0.031780s |  3.2088 |
+| Mahalanobis | 0.105060s |  0.031806s |  3.3032 |
 
 We can see that using ``colwise`` instead of a simple loop yields considerable gain (2x - 4x), especially when the internal computation of each distance is simple. Nonetheless, when the computation of a single distance is heavy enough (e.g. *KLDivergence*,  *RenyiDivergence*), the gain is not as significant.
 
@@ -226,29 +226,29 @@ The table below compares the performance (measured in terms of average elapsed t
 
 |  distance  |  loop  |  pairwise |  gain  |
 |----------- | -------| ----------| -------|
-| SqEuclidean | 0.022127s |  0.000145s | **152.1941** |
-| Euclidean | 0.021477s |  0.000844s | **25.4365** |
-| Cityblock | 0.021622s |  0.004129s |  5.2366 |
-| Chebyshev | 0.033059s |  0.015156s |  2.1813 |
-| Minkowski | 0.063735s |  0.046181s |  1.3801 |
-| Hamming | 0.020737s |  0.003304s |  6.2757 |
-| CosineDist | 0.025623s |  0.000831s | **30.8470** |
-| CorrDist | 0.035662s |  0.000888s | **40.1586** |
-| ChiSqDist | 0.021997s |  0.004236s |  5.1928 |
-| KLDivergence | 0.094585s |  0.083738s |  1.1295 |
-| RenyiDivergence(0) | 0.041105s |  0.022306s |  1.8428 |
-| RenyiDivergence(1) | 0.112891s |  0.100909s |  1.1187 |
-| RenyiDivergence(2) | 0.048346s |  0.031279s |  1.5456 |
-| RenyiDivergence(∞) | 0.042273s |  0.026941s |  1.5691 |
-| JSDivergence | 0.203695s |  0.195379s |  1.0426 |
-| BhattacharyyaDist | 0.029058s |  0.010801s |  2.6904 |
-| HellingerDist | 0.027940s |  0.009818s |  2.8458 |
-| WeightedSqEuclidean | 0.022282s |  0.000173s | **128.5042** |
-| WeightedEuclidean | 0.022500s |  0.000268s | **84.1009** |
-| WeightedCityblock | 0.022641s |  0.004501s |  5.0296 |
-| WeightedMinkowski | 0.066117s |  0.047862s |  1.3814 |
-| WeightedHamming | 0.027153s |  0.007034s |  3.8601 |
-| SqMahalanobis | 0.338031s |  0.000863s | **391.9013** |
-| Mahalanobis | 0.341765s |  0.000953s | **358.5008** |
+| SqEuclidean | 0.022982s |  0.000145s | **158.9554** |
+| Euclidean | 0.022155s |  0.000843s | **26.2716** |
+| Cityblock | 0.022382s |  0.003899s |  5.7407 |
+| Chebyshev | 0.034491s |  0.014600s |  2.3624 |
+| Minkowski | 0.065968s |  0.046761s |  1.4107 |
+| Hamming | 0.021016s |  0.003139s |  6.6946 |
+| CosineDist | 0.024394s |  0.000828s | **29.4478** |
+| CorrDist | 0.039089s |  0.000852s | **45.8839** |
+| ChiSqDist | 0.022152s |  0.004361s |  5.0793 |
+| KLDivergence | 0.096694s |  0.086728s |  1.1149 |
+| RenyiDivergence(0) | 0.042658s |  0.023323s |  1.8290 |
+| RenyiDivergence(1) | 0.122015s |  0.104527s |  1.1673 |
+| RenyiDivergence(2) | 0.052896s |  0.033865s |  1.5620 |
+| RenyiDivergence(∞) | 0.039993s |  0.027331s |  1.4632 |
+| JSDivergence | 0.211276s |  0.204046s |  1.0354 |
+| BhattacharyyaDist | 0.030378s |  0.011189s |  2.7151 |
+| HellingerDist | 0.029592s |  0.010109s |  2.9273 |
+| WeightedSqEuclidean | 0.025619s |  0.000217s | **117.8128** |
+| WeightedEuclidean | 0.023366s |  0.000264s | **88.3711** |
+| WeightedCityblock | 0.026213s |  0.004610s |  5.6855 |
+| WeightedMinkowski | 0.068588s |  0.050033s |  1.3708 |
+| WeightedHamming | 0.025936s |  0.007225s |  3.5895 |
+| SqMahalanobis | 0.520046s |  0.000939s | **553.6694** |
+| Mahalanobis | 0.480556s |  0.000954s | **503.6009** |
 
 For distances of which a major part of the computation is a quadratic form (e.g. *Euclidean*, *CosineDist*, *Mahalanobis*), the performance can be drastically improved by restructuring the computation and delegating the core part to ``GEMM`` in *BLAS*. The use of this strategy can easily lead to 100x performance gain over simple loops (see the highlighted part of the table above).

--- a/README.md
+++ b/README.md
@@ -131,15 +131,15 @@ Each distance corresponds to a distance type. The type name and the correspondin
 |  Cityblock           |  `cityblock(x, y)`         | `sum(abs(x - y))` |
 |  Chebyshev           |  `chebyshev(x, y)`         | `max(abs(x - y))` |
 |  Minkowski           |  `minkowski(x, y, p)`      | `sum(abs(x - y).^p) ^ (1/p)` |
-|  Hamming             |  `hamming(x, y)`           | `sum(x .!= y)` |
-|  Rogers-Tanimoto     |  `rogerstanimoto(x, y)`    | `2(sum(x&!y) + sum(!x&y)) / (2(sum(x&!y) + sum(!x&y)) + sum(x&y) + sum(!x&!y))` |
+|  Hamming             |  `hamming(k, l)`           | `sum(k .!= l)` |
+|  Rogers-Tanimoto     |  `rogerstanimoto(a, b)`    | `2(sum(a&!b) + sum(!a&b)) / (2(sum(a&!b) + sum(!a&b)) + sum(a&b) + sum(!a&!b))` |
 |  Jaccard             |  `jaccard(x, y)`           | `1 - sum(min(x, y)) / sum(max(x, y))` |
 |  CosineDist          |  `cosine_dist(x, y)`       | `1 - dot(x, y) / (norm(x) * norm(y))` |
 |  CorrDist            |  `corr_dist(x, y)`         | `cosine_dist(x - mean(x), y - mean(y))` |
 |  ChiSqDist           |  `chisq_dist(x, y)`        | `sum((x - y).^2 / (x + y))` |
-|  KLDivergence        |  `kl_divergence(x, y)`     | `sum(p .* log(p ./ q))` |
-|  RenyiDivergence     | `renyi_divergence(x, y, k)`| `log(sum( x .* (x ./ y) .^ (k - 1))) / (k - 1)` |
-|  JSDivergence        |  `js_divergence(x, y)`     | `KL(x, m) / 2 + KL(y, m) / 2 with m = (x + y) / 2` |
+|  KLDivergence        |  `kl_divergence(p, q)`     | `sum(p .* log(p ./ q))` |
+|  RenyiDivergence     | `renyi_divergence(p, q, k)`| `log(sum( p .* (p ./ q) .^ (k - 1))) / (k - 1)` |
+|  JSDivergence        |  `js_divergence(p, q)`     | `KL(p, m) / 2 + KL(p, m) / 2 with m = (p + q) / 2` |
 |  SpanNormDist        |  `spannorm_dist(x, y)`     | `max(x - y) - min(x - y )` |
 |  BhattacharyyaDist   |  `bhattacharyya(x, y)`     | `-log(sum(sqrt(x .* y) / sqrt(sum(x) * sum(y)))` |
 |  HellingerDist       |  `hellinger(x, y) `        | `sqrt(1 - sum(sqrt(x .* y) / sqrt(sum(x) * sum(y))))` |
@@ -151,7 +151,7 @@ Each distance corresponds to a distance type. The type name and the correspondin
 |  WeightedMinkowski   |  `wminkowski(x, y, w, p)`  | `sum(abs(x - y).^p .* w) ^ (1/p)` |
 |  WeightedHamming     |  `whamming(x, y, w)`       | `sum((x .!= y) .* w)`  |
 
-**Note:** The formulas above are using *Julia*'s functions. These formulas are mainly for conveying the math concepts in a concise way. The actual implementation may use a faster way.
+**Note:** The formulas above are using *Julia*'s functions. These formulas are mainly for conveying the math concepts in a concise way. The actual implementation may use a faster way. x and y arguments are arrays of real numbers; k and l arguments are arrays of distinct elements of any kind; a and b arguments are arrays of `Bool`s; and p and q arguments are arrays forming a discrete probability distribution and are therefore expected to sum to one.
 
 ### Precision for Euclidean and SqEuclidean
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Each distance corresponds to a distance type. The type name and the correspondin
 |  WeightedMinkowski   |  `wminkowski(x, y, w, p)`  | `sum(abs(x - y).^p .* w) ^ (1/p)` |
 |  WeightedHamming     |  `whamming(x, y, w)`       | `sum((x .!= y) .* w)`  |
 
-**Note:** The formulas above are using *Julia*'s functions. These formulas are mainly for conveying the math concepts in a concise way. The actual implementation may use a faster way. x and y arguments are arrays of real numbers; k and l arguments are arrays of distinct elements of any kind; a and b arguments are arrays of `Bool`s; and p and q arguments are arrays forming a discrete probability distribution and are therefore expected to sum to one.
+**Note:** The formulas above are using *Julia*'s functions. These formulas are mainly for conveying the math concepts in a concise way. The actual implementation may use a faster way. The arguments `x` and `y` are arrays of real numbers; `k` and `l` are arrays of distinct elements of any kind; a and b are arrays of Bools; and finally, `p` and `q` are arrays forming a discrete probability distribution and are therefore both expected to sum to one.
 
 ### Precision for Euclidean and SqEuclidean
 

--- a/src/bhattacharyya.jl
+++ b/src/bhattacharyya.jl
@@ -10,6 +10,10 @@ type HellingerDist <: Metric end
 # Bhattacharyya coefficient
 
 function bhattacharyya_coeff{T<:Number}(a::AbstractVector{T}, b::AbstractVector{T})
+    if length(a) != length(b)
+        throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
+    end
+
     n = length(a)
     sqab = zero(T)
     # We must normalize since we cannot assume that the vectors are normalized to probability vectors.

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -14,6 +14,10 @@ result_type{T}(::SqMahalanobis{T}, ::AbstractArray, ::AbstractArray) = T
 # SqMahalanobis
 
 function evaluate{T<:AbstractFloat}(dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractVector)
+    if length(a) != length(b)
+        throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
+    end
+    
     Q = dist.qmat
     z = a - b
     return dot(z, Q * z)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -29,6 +29,40 @@ type CorrDist <: SemiMetric end
 type ChiSqDist <: SemiMetric end
 type KLDivergence <: PreMetric end
 
+"""
+    RenyiDivergence(α::Real)
+    renyi_divergence(P, Q, α::Real)
+
+Create a Rényi premetric of order α.
+
+Rényi defined a spectrum of divergence measures generalising the
+Kullback–Leibler divergence (see `KLDivergence`). The divergence is
+not a semimetric as it is not symmetric. It is parameterised by a
+parameter α, and is equal to Kullback–Leibler divergence at α = 1:
+
+At α = 0, ``R_0(P | Q) = -log(sum_{i: p_i > 0}(q_i))``
+
+At α = 1, ``R_1(P | Q) = sum_{i: p_i > 0}(p_i log(p_i / q_i))``
+
+At α = ∞, ``R_∞(P | Q) = log(sup_{i: p_i > 0}(p_i / q_i))``
+
+Otherwise ``R_α(P | Q) = log(sum_{i: p_i > 0}((p_i ^ α) / (q_i ^ (α - 1))) / (α - 1)``
+
+# Example:
+```jldoctest
+julia> x = reshape([0.1, 0.3, 0.4, 0.2], 2, 2);
+
+julia> pairwise(RenyiDivergence(0), x, x)
+2×2 Array{Float64,2}:
+ 0.0  0.0
+ 0.0  0.0
+
+julia> pairwise(Euclidean(2), x, x)
+2×2 Array{Float64,2}:
+ 0.0       0.577315
+ 0.655407  0.0
+```
+"""
 immutable RenyiDivergence{T <: Real} <: PreMetric
     p::T # order of power mean (order of divergence - 1)
     is_normal::Bool
@@ -250,6 +284,9 @@ function eval_end{T<:AbstractFloat}(dist::RenyiDivergence, s::Tuple{T, T, T, T})
         log(s[2]) + log(s[4] / s[3])
     end
 end
+
+# Combine docs with RenyiDivergence
+@doc (@doc RenyiDivergence) renyi_divergence
 
 renyi_divergence(a::AbstractArray, b::AbstractArray, q::Real) = evaluate(RenyiDivergence(q), a, b)
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -59,14 +59,14 @@ type SpanNormDist <: SemiMetric end
 const UnionMetrics = Union{Euclidean, SqEuclidean, Chebyshev, Cityblock, Minkowski, Hamming, Jaccard, RogersTanimoto, CosineDist, CorrDist, ChiSqDist, KLDivergence, RenyiDivergence, JSDivergence, SpanNormDist}
 
 """
-    Euclidean([thresh])
+Euclidean([thresh])
 
 Create a euclidean metric.
 
 When computing distances among large numbers of points, it can be much
 more efficient to exploit the formula
 
-    (x-y)^2 = x^2 - 2xy + y^2
+(x-y)^2 = x^2 - 2xy + y^2
 
 However, this can introduce roundoff error. `thresh` (which defaults
 to 0) specifies the relative square-distance tolerance on `2xy`
@@ -89,7 +89,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
 Euclidean() = Euclidean(0)
 
 """
-    SqEuclidean([thresh])
+SqEuclidean([thresh])
 
 Create a squared-euclidean semi-metric. For the meaning of `thresh`,
 see [`Euclidean`](@ref).
@@ -310,11 +310,11 @@ jaccard(a::AbstractArray, b::AbstractArray) = evaluate(Jaccard(), a, b)
 
 @inline eval_start(::RogersTanimoto, a::AbstractArray, b::AbstractArray) = 0, 0, 0, 0
 @inline function eval_op(::RogersTanimoto, s1, s2)
-  tt = s1 && s2
-  tf = s1 && !s2
-  ft = !s1 && s2
-  ff = !s1 && !s2
-  tt, tf, ft, ff
+    tt = s1 && s2
+    tf = s1 && !s2
+    ft = !s1 && s2
+    ff = !s1 && !s2
+    tt, tf, ft, ff
 end
 @inline function eval_reduce(::RogersTanimoto, s1, s2)
     @inbounds begin

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -59,14 +59,14 @@ type SpanNormDist <: SemiMetric end
 const UnionMetrics = Union{Euclidean, SqEuclidean, Chebyshev, Cityblock, Minkowski, Hamming, Jaccard, RogersTanimoto, CosineDist, CorrDist, ChiSqDist, KLDivergence, RenyiDivergence, JSDivergence, SpanNormDist}
 
 """
-Euclidean([thresh])
+    Euclidean([thresh])
 
 Create a euclidean metric.
 
 When computing distances among large numbers of points, it can be much
 more efficient to exploit the formula
 
-(x-y)^2 = x^2 - 2xy + y^2
+    (x-y)^2 = x^2 - 2xy + y^2
 
 However, this can introduce roundoff error. `thresh` (which defaults
 to 0) specifies the relative square-distance tolerance on `2xy`
@@ -86,7 +86,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
  0.0
 ```
 """
-Euclidean() = Euclidean(0)
+    Euclidean() = Euclidean(0)
 
 """
 SqEuclidean([thresh])

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -86,7 +86,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
  0.0
 ```
 """
-    Euclidean() = Euclidean(0)
+Euclidean() = Euclidean(0)
 
 """
     SqEuclidean([thresh])

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -89,7 +89,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
     Euclidean() = Euclidean(0)
 
 """
-SqEuclidean([thresh])
+    SqEuclidean([thresh])
 
 Create a squared-euclidean semi-metric. For the meaning of `thresh`,
 see [`Euclidean`](@ref).

--- a/test/bench_colwise.jl
+++ b/test/bench_colwise.jl
@@ -28,6 +28,14 @@ n = 10000
 
 x = rand(m, n)
 y = rand(m, n)
+
+p = x
+q = y
+for i = 1:n
+    p[:,i] /= sum(x[:,i])
+    q[:,i] /= sum(y[:,i])
+end
+
 w = rand(m)
 
 Q = rand(m, m)
@@ -46,8 +54,12 @@ bench_colwise_distance(Hamming(), x, y)
 bench_colwise_distance(CosineDist(), x, y)
 bench_colwise_distance(CorrDist(), x, y)
 bench_colwise_distance(ChiSqDist(), x, y)
-bench_colwise_distance(KLDivergence(), x, y)
-bench_colwise_distance(JSDivergence(), x, y)
+bench_colwise_distance(KLDivergence(), p, q)
+bench_colwise_distance(RenyiDivergence(0), p, q)
+bench_colwise_distance(RenyiDivergence(1), p, q)
+bench_colwise_distance(RenyiDivergence(2), p, q)
+bench_colwise_distance(RenyiDivergence(Inf), p, q)
+bench_colwise_distance(JSDivergence(), p, q)
 
 bench_colwise_distance(BhattacharyyaDist(), x, y)
 bench_colwise_distance(HellingerDist(), x, y)

--- a/test/bench_pairwise.jl
+++ b/test/bench_pairwise.jl
@@ -33,6 +33,16 @@ ny = 250
 x = rand(m, nx)
 y = rand(m, ny)
 
+p = x
+for i = 1:nx
+    p[:,i] /= sum(x[:,i])
+end
+
+q = y
+for i = 1:ny
+    q[:,i] /= sum(y[:,i])
+end
+
 w = rand(m)
 Q = rand(m, m)
 Q = Q' * Q
@@ -50,8 +60,12 @@ bench_pairwise_distance(Hamming(), x, y)
 bench_pairwise_distance(CosineDist(), x, y)
 bench_pairwise_distance(CorrDist(), x, y)
 bench_pairwise_distance(ChiSqDist(), x, y)
-bench_pairwise_distance(KLDivergence(), x, y)
-bench_pairwise_distance(JSDivergence(), x, y)
+bench_pairwise_distance(KLDivergence(), p, q)
+bench_pairwise_distance(RenyiDivergence(0), p, q)
+bench_pairwise_distance(RenyiDivergence(1), p, q)
+bench_pairwise_distance(RenyiDivergence(2), p, q)
+bench_pairwise_distance(RenyiDivergence(Inf), p, q)
+bench_pairwise_distance(JSDivergence(), p, q)
 
 bench_pairwise_distance(BhattacharyyaDist(), x, y)
 bench_pairwise_distance(HellingerDist(), x, y)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -9,7 +9,7 @@ macro test_metricity(_dist, _x, _y, _z)
         dxy = evaluate(dist, x, y)
         dxz = evaluate(dist, x, z)
         dyz = evaluate(dist, y, z)
-        if (isa(dist, PreMetric))
+        if isa(dist, PreMetric)
             # Unfortunately small non-zero numbers (~10^-16) are appearing
             # in our tests due to accumulating floating point rounding errors.
             # We either need to allow small errors in our tests or change the
@@ -21,7 +21,7 @@ macro test_metricity(_dist, _x, _y, _z)
             @test dxz ≥ zero(eltype(x))
             @test dyz ≥ zero(eltype(x))
         end
-        if (isa(dist, SemiMetric))
+        if isa(dist, SemiMetric)
             @test dxy ≈ evaluate(dist, y, x)
             @test dxz ≈ evaluate(dist, z, x)
             @test dyz ≈ evaluate(dist, y, z)
@@ -30,7 +30,7 @@ macro test_metricity(_dist, _x, _y, _z)
             @test evaluate(dist, z, x) ≥ zero(eltype(x))
             @test evaluate(dist, z, y) ≥ zero(eltype(x))
         end
-        if (isa(dist, Metric))
+        if isa(dist, Metric)
             @test dxz ≤ dxy + dyz
             @test dyz ≤ evaluate(dist, y, x) + dxz
             @test dxy ≤ dxz + evaluate(dist, z, y)
@@ -40,175 +40,175 @@ end
 
 @testset "PreMetric, SemiMetric, Metric" begin
 
-n = 10
-x = rand(n)
-y = rand(n)
-z = rand(n)
+    n = 10
+    x = rand(n)
+    y = rand(n)
+    z = rand(n)
 
-@test_metricity SqEuclidean() x y z
-@test_metricity Euclidean() x y z
-@test_metricity Cityblock() x y z
-@test_metricity Chebyshev() x y z
-@test_metricity Minkowski(2.5) x y z
+    @test_metricity SqEuclidean() x y z
+    @test_metricity Euclidean() x y z
+    @test_metricity Cityblock() x y z
+    @test_metricity Chebyshev() x y z
+    @test_metricity Minkowski(2.5) x y z
 
-@test_metricity CosineDist() x y z
-@test_metricity CorrDist() x y z
+    @test_metricity CosineDist() x y z
+    @test_metricity CorrDist() x y z
 
-@test_metricity ChiSqDist() x y z
+    @test_metricity ChiSqDist() x y z
 
-@test_metricity Jaccard() x y z
-@test_metricity SpanNormDist() x y z
+    @test_metricity Jaccard() x y z
+    @test_metricity SpanNormDist() x y z
 
-@test_metricity BhattacharyyaDist() x y z
-@test_metricity HellingerDist() x y z
+    @test_metricity BhattacharyyaDist() x y z
+    @test_metricity HellingerDist() x y z
 
-k = rand(1:3, n)
-l = rand(1:3, n)
-m = rand(1:3, n)
+    k = rand(1:3, n)
+    l = rand(1:3, n)
+    m = rand(1:3, n)
 
-@test_metricity Hamming() k l m
+    @test_metricity Hamming() k l m
 
-a = rand(Bool, n)
-b = rand(Bool, n)
-c = rand(Bool, n)
+    a = rand(Bool, n)
+    b = rand(Bool, n)
+    c = rand(Bool, n)
 
-@test_metricity RogersTanimoto() a b c
-@test_metricity Jaccard() a b c
+    @test_metricity RogersTanimoto() a b c
+    @test_metricity Jaccard() a b c
 
-w = rand(n)
+    w = rand(n)
 
-@test_metricity WeightedSqEuclidean(w) x y z
-@test_metricity WeightedEuclidean(w) x y z
-@test_metricity WeightedCityblock(w) x y z
-@test_metricity WeightedMinkowski(w, 2.5) x y z
-@test_metricity WeightedHamming(w) a b c
+    @test_metricity WeightedSqEuclidean(w) x y z
+    @test_metricity WeightedEuclidean(w) x y z
+    @test_metricity WeightedCityblock(w) x y z
+    @test_metricity WeightedMinkowski(w, 2.5) x y z
+    @test_metricity WeightedHamming(w) a b c
 
-Q = rand(n, n)
-Q = Q * Q'  # make sure Q is positive-definite
+    Q = rand(n, n)
+    Q = Q * Q'  # make sure Q is positive-definite
 
-@test_metricity SqMahalanobis(Q) x y z
-@test_metricity Mahalanobis(Q) x y z
+    @test_metricity SqMahalanobis(Q) x y z
+    @test_metricity Mahalanobis(Q) x y z
 
-p = rand(n)
-q = rand(n)
-r = rand(n)
-p[p .< median(p)] = 0
-p /= sum(p)
-q /= sum(q)
-r /= sum(r)
+    p = rand(n)
+    q = rand(n)
+    r = rand(n)
+    p[p .< median(p)] = 0
+    p /= sum(p)
+    q /= sum(q)
+    r /= sum(r)
 
-@test_metricity KLDivergence() p q r
-@test_metricity RenyiDivergence(0.0) p q r
-@test_metricity RenyiDivergence(1.0) p q r
-@test_metricity RenyiDivergence(Inf) p q r
-@test_metricity RenyiDivergence(0.5) p q r
-@test_metricity RenyiDivergence(2) p q r
-@test_metricity RenyiDivergence(10) p q r
-@test_metricity JSDivergence() p q r
+    @test_metricity KLDivergence() p q r
+    @test_metricity RenyiDivergence(0.0) p q r
+    @test_metricity RenyiDivergence(1.0) p q r
+    @test_metricity RenyiDivergence(Inf) p q r
+    @test_metricity RenyiDivergence(0.5) p q r
+    @test_metricity RenyiDivergence(2) p q r
+    @test_metricity RenyiDivergence(10) p q r
+    @test_metricity JSDivergence() p q r
 
 end
 
 @testset "individual metrics" begin
 
-a = 1
-b = 2
-@test sqeuclidean(a, b) == 1.0
+    a = 1
+    b = 2
+    @test sqeuclidean(a, b) == 1.0
 
-@test euclidean(a, b) == 1.0
-@test cityblock(a, b) == 1.0
-@test chebyshev(a, b) == 1.0
-@test minkowski(a, b, 2) == 1.0
-@test hamming(a, b) == 1
+    @test euclidean(a, b) == 1.0
+    @test cityblock(a, b) == 1.0
+    @test chebyshev(a, b) == 1.0
+    @test minkowski(a, b, 2) == 1.0
+    @test hamming(a, b) == 1
 
-bt = [true, false, true]
-bf = [false, true, true]
-@test rogerstanimoto(bt, bt) == 0
-@test rogerstanimoto(bt, bf) == 4.0/5.0
+    bt = [true, false, true]
+    bf = [false, true, true]
+    @test rogerstanimoto(bt, bt) == 0
+    @test rogerstanimoto(bt, bf) == 4.0/5.0
 
-for (x, y) in (([4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]),
-               ([4.0, 5.0, 6.0, 7.0], [3. 8.; 9. 1.0]))
-    @test sqeuclidean(x, y) == 57.0
+    for (x, y) in (([4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]),
+                   ([4.0, 5.0, 6.0, 7.0], [3. 8.; 9. 1.0]))
+        @test sqeuclidean(x, y) == 57.0
 
-    @test euclidean(x, y) == sqrt(57.0)
+        @test euclidean(x, y) == sqrt(57.0)
 
-    @test jaccard(x, y) == 13.0/28
+        @test jaccard(x, y) == 13.0/28
 
-    @test cityblock(x, y) == 13.0
+        @test cityblock(x, y) == 13.0
 
-    @test chebyshev(x, y) == 6.0
+        @test chebyshev(x, y) == 6.0
 
-    @test minkowski(x, y, 2) == sqrt(57.0)
+        @test minkowski(x, y, 2) == sqrt(57.0)
 
-    @test_throws DimensionMismatch cosine_dist(1.0:2, 1.0:3)
-    @test cosine_dist(x, y) ≈ (1.0 - 112. / sqrt(19530.0))
-    x_int, y_int = map(Int64, x), map(Int64, y)
-    @test cosine_dist(x_int, y_int) == (1.0 - 112.0 / sqrt(19530.0))
+        @test_throws DimensionMismatch cosine_dist(1.0:2, 1.0:3)
+        @test cosine_dist(x, y) ≈ (1.0 - 112. / sqrt(19530.0))
+        x_int, y_int = map(Int64, x), map(Int64, y)
+        @test cosine_dist(x_int, y_int) == (1.0 - 112.0 / sqrt(19530.0))
 
-    @test corr_dist(x, y) ≈ cosine_dist(x .- mean(x), vec(y) .- mean(y))
+        @test corr_dist(x, y) ≈ cosine_dist(x .- mean(x), vec(y) .- mean(y))
 
-    @test chisq_dist(x, y) == sum((x - vec(y)).^2 ./ (x + vec(y)))
+        @test chisq_dist(x, y) == sum((x - vec(y)).^2 ./ (x + vec(y)))
 
-    @test spannorm_dist(x, y) == maximum(x - vec(y)) - minimum(x - vec(y))
-
-
-
-    w = ones(4)
-    @test sqeuclidean(x, y) ≈ wsqeuclidean(x, y, w)
+        @test spannorm_dist(x, y) == maximum(x - vec(y)) - minimum(x - vec(y))
 
 
-    w = rand(size(x))
 
-    @test wsqeuclidean(x, y, w) ≈ dot((x - vec(y)).^2, w)
+        w = ones(4)
+        @test sqeuclidean(x, y) ≈ wsqeuclidean(x, y, w)
 
-    @test weuclidean(x, y, w) == sqrt(wsqeuclidean(x, y, w))
 
-    @test wcityblock(x, y, w) ≈ dot(abs.(x - vec(y)), w)
+        w = rand(size(x))
 
-    @test wminkowski(x, y, w, 2) ≈ weuclidean(x, y, w)
-end
+        @test wsqeuclidean(x, y, w) ≈ dot((x - vec(y)).^2, w)
 
-# Test weighted Hamming distances with even weights
-a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
-b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
-w = rand(size(a))
+        @test weuclidean(x, y, w) == sqrt(wsqeuclidean(x, y, w))
 
-@test whamming(a, a, w) == 0.0
-@test whamming(a, b, w) == sum((a .!= b) .* w)
+        @test wcityblock(x, y, w) ≈ dot(abs.(x - vec(y)), w)
 
-# Minimal test of Jaccard - test return type stability.
-@inferred evaluate(Jaccard(), rand(3), rand(3))
-@inferred evaluate(Jaccard(), [1,2,3], [1,2,3])
-@inferred evaluate(Jaccard(), [true, false, true], [false, true, true])
-
-# Test KL, Renyi and JS divergences
-p = r = rand(12)
-p[p .< median(p)] = 0.0
-scale = sum(p) / sum(r)
-r /= sum(r)
-p /= sum(p)
-q = rand(12)
-q /= sum(q)
-
-klv = 0.0
-for i = 1 : length(p)
-    if p[i] > 0
-        klv += p[i] * log(p[i] / q[i])
+        @test wminkowski(x, y, w, 2) ≈ weuclidean(x, y, w)
     end
-end
-@test kl_divergence(p, q) ≈ klv
 
-@test renyi_divergence(p, r, 0) ≈ -log(scale)
-@test renyi_divergence(p, r, 1) ≈ -log(scale)
-@test renyi_divergence(p, r, 10) ≈ -log(scale)
-@test renyi_divergence(p, r, rand()) ≈ -log(scale)
-@test renyi_divergence(p, r, Inf) ≈ -log(scale)
-@test isinf(renyi_divergence([0.0, 0.5, 0.5], [0.0, 1.0, 0.0], Inf))
-@test renyi_divergence([0.0, 1.0, 0.0], [0.0, 0.5, 0.5], Inf) ≈ log(2.0)
-@test renyi_divergence(p, q, 1) ≈ kl_divergence(p, q)
+    # Test weighted Hamming distances with even weights
+    a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
+    b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
+    w = rand(size(a))
 
-pm = (p + q) / 2
-jsv = kl_divergence(p, pm) / 2 + kl_divergence(q, pm) / 2
-@test js_divergence(p, q) ≈ jsv
+    @test whamming(a, a, w) == 0.0
+    @test whamming(a, b, w) == sum((a .!= b) .* w)
+
+    # Minimal test of Jaccard - test return type stability.
+    @inferred evaluate(Jaccard(), rand(3), rand(3))
+    @inferred evaluate(Jaccard(), [1,2,3], [1,2,3])
+    @inferred evaluate(Jaccard(), [true, false, true], [false, true, true])
+
+    # Test KL, Renyi and JS divergences
+    p = r = rand(12)
+    p[p .< median(p)] = 0.0
+    scale = sum(p) / sum(r)
+    r /= sum(r)
+    p /= sum(p)
+    q = rand(12)
+    q /= sum(q)
+
+    klv = 0.0
+    for i = 1 : length(p)
+        if p[i] > 0
+            klv += p[i] * log(p[i] / q[i])
+        end
+    end
+    @test kl_divergence(p, q) ≈ klv
+
+    @test renyi_divergence(p, r, 0) ≈ -log(scale)
+    @test renyi_divergence(p, r, 1) ≈ -log(scale)
+    @test renyi_divergence(p, r, 10) ≈ -log(scale)
+    @test renyi_divergence(p, r, rand()) ≈ -log(scale)
+    @test renyi_divergence(p, r, Inf) ≈ -log(scale)
+    @test isinf(renyi_divergence([0.0, 0.5, 0.5], [0.0, 1.0, 0.0], Inf))
+    @test renyi_divergence([0.0, 1.0, 0.0], [0.0, 0.5, 0.5], Inf) ≈ log(2.0)
+    @test renyi_divergence(p, q, 1) ≈ kl_divergence(p, q)
+
+    pm = (p + q) / 2
+    jsv = kl_divergence(p, pm) / 2 + kl_divergence(q, pm) / 2
+    @test js_divergence(p, q) ≈ jsv
 
 
 end # testset
@@ -216,115 +216,115 @@ end # testset
 
 @testset "NaN behavior" begin
 
-a = [NaN, 0]; b = [0, NaN]
-@test isnan(chebyshev(a, b)) == isnan(maximum(a-b))
-a = [NaN, 0]; b = [0, 1]
-@test isnan(chebyshev(a, b)) == isnan(maximum(a-b))
-@test isnan(renyi_divergence([0.5, 0.0, 0.5], [0.5, 0.5, NaN], 2))
+    a = [NaN, 0]; b = [0, NaN]
+    @test isnan(chebyshev(a, b)) == isnan(maximum(a-b))
+    a = [NaN, 0]; b = [0, 1]
+    @test isnan(chebyshev(a, b)) == isnan(maximum(a-b))
+    @test isnan(renyi_divergence([0.5, 0.0, 0.5], [0.5, 0.5, NaN], 2))
 end #testset
 
 
 @testset "empty vector" begin
 
-a = Float64[]
-b = Float64[]
-@test sqeuclidean(a, b) == 0.0
-@test isa(sqeuclidean(a, b), Float64)
-@test euclidean(a, b) == 0.0
-@test isa(euclidean(a, b), Float64)
-@test cityblock(a, b) == 0.0
-@test isa(cityblock(a, b), Float64)
-@test chebyshev(a, b) == 0.0
-@test isa(chebyshev(a, b), Float64)
-@test minkowski(a, b, 2) == 0.0
-@test isa(minkowski(a, b, 2), Float64)
-@test hamming(a, b) == 0.0
-@test isa(hamming(a, b), Int)
-@test renyi_divergence(a, b, 1.0) == 0.0
-@test isa(renyi_divergence(a, b, 2.0), Float64)
+    a = Float64[]
+    b = Float64[]
+    @test sqeuclidean(a, b) == 0.0
+    @test isa(sqeuclidean(a, b), Float64)
+    @test euclidean(a, b) == 0.0
+    @test isa(euclidean(a, b), Float64)
+    @test cityblock(a, b) == 0.0
+    @test isa(cityblock(a, b), Float64)
+    @test chebyshev(a, b) == 0.0
+    @test isa(chebyshev(a, b), Float64)
+    @test minkowski(a, b, 2) == 0.0
+    @test isa(minkowski(a, b, 2), Float64)
+    @test hamming(a, b) == 0.0
+    @test isa(hamming(a, b), Int)
+    @test renyi_divergence(a, b, 1.0) == 0.0
+    @test isa(renyi_divergence(a, b, 2.0), Float64)
 
-w = Float64[]
-@test isa(whamming(a, b, w), Float64)
+    w = Float64[]
+    @test isa(whamming(a, b, w), Float64)
 
 end # testset
 
 
 @testset "DimensionMismatch throwing" begin
 
-a = [1, 0]; b = [2]
-@test_throws DimensionMismatch sqeuclidean(a, b)
-a = [1, 0]; b = [2.0] ; w = [3.0]
-@test_throws DimensionMismatch wsqeuclidean(a, b, w)
-a = [1, 0]; b = [2.0, 4.0] ; w = [3.0]
-@test_throws DimensionMismatch wsqeuclidean(a, b, w)
-p = [0.5, 0.5]; q = [0.3, 0.3, 0.4]
-@test_throws DimensionMismatch bhattacharyya(p, q)
-@test_throws DimensionMismatch hellinger(q, p)
-Q = rand(length(p), length(p))
-Q = Q * Q'  # make sure Q is positive-definite
-@test_throws DimensionMismatch mahalanobis(p, q, Q)
-@test_throws DimensionMismatch mahalanobis(q, q, Q)
-mat23 = [0.3 0.2 0.0; 0.1 0.0 0.4]
-mat22 = [0.3 0.2; 0.1 0.4]
-@test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat23)
-@test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, q)
-@test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat22)
+    a = [1, 0]; b = [2]
+    @test_throws DimensionMismatch sqeuclidean(a, b)
+    a = [1, 0]; b = [2.0] ; w = [3.0]
+    @test_throws DimensionMismatch wsqeuclidean(a, b, w)
+    a = [1, 0]; b = [2.0, 4.0] ; w = [3.0]
+    @test_throws DimensionMismatch wsqeuclidean(a, b, w)
+    p = [0.5, 0.5]; q = [0.3, 0.3, 0.4]
+    @test_throws DimensionMismatch bhattacharyya(p, q)
+    @test_throws DimensionMismatch hellinger(q, p)
+    Q = rand(length(p), length(p))
+    Q = Q * Q'  # make sure Q is positive-definite
+    @test_throws DimensionMismatch mahalanobis(p, q, Q)
+    @test_throws DimensionMismatch mahalanobis(q, q, Q)
+    mat23 = [0.3 0.2 0.0; 0.1 0.0 0.4]
+    mat22 = [0.3 0.2; 0.1 0.4]
+    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat23)
+    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, q)
+    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat22)
 
 end # testset
 
 
 @testset "mahalanobis" begin
 
-x, y = [4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]
-a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
-b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
+    x, y = [4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]
+    a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
+    b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
 
-Q = rand(length(x), length(x))
-Q = Q * Q'  # make sure Q is positive-definite
-@test sqmahalanobis(x, y, Q) ≈ dot(x - y, Q * (x - y))
+    Q = rand(length(x), length(x))
+    Q = Q * Q'  # make sure Q is positive-definite
+    @test sqmahalanobis(x, y, Q) ≈ dot(x - y, Q * (x - y))
 
-@test mahalanobis(x, y, Q) == sqrt(sqmahalanobis(x, y, Q))
+    @test mahalanobis(x, y, Q) == sqrt(sqmahalanobis(x, y, Q))
 
 end #testset
 
 
 @testset "bhattacharyya / hellinger" begin
 
-x, y = [4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]
-a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
-b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
-p = rand(12)
-p[p .< median(p)] = 0.0
-q = rand(12)
+    x, y = [4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]
+    a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
+    b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
+    p = rand(12)
+    p[p .< median(p)] = 0.0
+    q = rand(12)
 
-# Bhattacharyya and Hellinger distances are defined for discrete
-# probability distributions so to calculate the expected values
-# we need to normalize vectors.
-px = x ./ sum(x)
-py = y ./ sum(y)
-expected_bc_x_y = sum(sqrt.(px .* py))
-@test Distances.bhattacharyya_coeff(x, y) ≈ expected_bc_x_y
-@test bhattacharyya(x, y) ≈ (-log(expected_bc_x_y))
-@test hellinger(x, y) ≈ sqrt(1 - expected_bc_x_y)
+    # Bhattacharyya and Hellinger distances are defined for discrete
+    # probability distributions so to calculate the expected values
+    # we need to normalize vectors.
+    px = x ./ sum(x)
+    py = y ./ sum(y)
+    expected_bc_x_y = sum(sqrt.(px .* py))
+    @test Distances.bhattacharyya_coeff(x, y) ≈ expected_bc_x_y
+    @test bhattacharyya(x, y) ≈ (-log(expected_bc_x_y))
+    @test hellinger(x, y) ≈ sqrt(1 - expected_bc_x_y)
 
 
 
-pa = a ./ sum(a)
-pb = b ./ sum(b)
-expected_bc_a_b = sum(sqrt.(pa .* pb))
-@test Distances.bhattacharyya_coeff(a, b) ≈ expected_bc_a_b
-@test bhattacharyya(a, b) ≈ (-log(expected_bc_a_b))
-@test hellinger(a, b) ≈ sqrt(1 - expected_bc_a_b)
+    pa = a ./ sum(a)
+    pb = b ./ sum(b)
+    expected_bc_a_b = sum(sqrt.(pa .* pb))
+    @test Distances.bhattacharyya_coeff(a, b) ≈ expected_bc_a_b
+    @test bhattacharyya(a, b) ≈ (-log(expected_bc_a_b))
+    @test hellinger(a, b) ≈ sqrt(1 - expected_bc_a_b)
 
-pp = p ./ sum(p)
-pq = q ./ sum(q)
-expected_bc_p_q = sum(sqrt.(pp .* pq))
-@test Distances.bhattacharyya_coeff(p, q) ≈ expected_bc_p_q
-@test bhattacharyya(p, q) ≈ (-log(expected_bc_p_q))
-@test hellinger(p, q) ≈ sqrt(1 - expected_bc_p_q)
+    pp = p ./ sum(p)
+    pq = q ./ sum(q)
+    expected_bc_p_q = sum(sqrt.(pp .* pq))
+    @test Distances.bhattacharyya_coeff(p, q) ≈ expected_bc_p_q
+    @test bhattacharyya(p, q) ≈ (-log(expected_bc_p_q))
+    @test hellinger(p, q) ≈ sqrt(1 - expected_bc_p_q)
 
-# Ensure it is semimetric
-@test bhattacharyya(x, y) ≈ bhattacharyya(y, x)
+    # Ensure it is semimetric
+    @test bhattacharyya(x, y) ≈ bhattacharyya(y, x)
 
 end #testset
 
@@ -351,57 +351,57 @@ end
 
 @testset "column-wise metrics" begin
 
-m = 5
-n = 8
-X = rand(m, n)
-Y = rand(m, n)
-A = rand(1:3, m, n)
-B = rand(1:3, m, n)
+    m = 5
+    n = 8
+    X = rand(m, n)
+    Y = rand(m, n)
+    A = rand(1:3, m, n)
+    B = rand(1:3, m, n)
 
-P = rand(m, n)
-Q = rand(m, n)
-# Make sure not to remove all of the non-zeros from any column
-for i in 1:n
-    P[P[:, i] .< median(P[:, i])/2, i] = 0.0
-end
+    P = rand(m, n)
+    Q = rand(m, n)
+    # Make sure not to remove all of the non-zeros from any column
+    for i in 1:n
+        P[P[:, i] .< median(P[:, i])/2, i] = 0.0
+    end
 
-@test_colwise SqEuclidean() X Y
-@test_colwise Euclidean() X Y
-@test_colwise Cityblock() X Y
-@test_colwise Chebyshev() X Y
-@test_colwise Minkowski(2.5) X Y
-@test_colwise Hamming() A B
+    @test_colwise SqEuclidean() X Y
+    @test_colwise Euclidean() X Y
+    @test_colwise Cityblock() X Y
+    @test_colwise Chebyshev() X Y
+    @test_colwise Minkowski(2.5) X Y
+    @test_colwise Hamming() A B
 
-@test_colwise CosineDist() X Y
-@test_colwise CorrDist() X Y
+    @test_colwise CosineDist() X Y
+    @test_colwise CorrDist() X Y
 
-@test_colwise ChiSqDist() X Y
-@test_colwise KLDivergence() P Q
-@test_colwise RenyiDivergence(0.0) P Q
-@test_colwise RenyiDivergence(1.0) P Q
-@test_colwise RenyiDivergence(Inf) P Q
-@test_colwise RenyiDivergence(0.5) P Q
-@test_colwise RenyiDivergence(2) P Q
-@test_colwise RenyiDivergence(10) P Q
-@test_colwise JSDivergence() P Q
-@test_colwise SpanNormDist() X Y
+    @test_colwise ChiSqDist() X Y
+    @test_colwise KLDivergence() P Q
+    @test_colwise RenyiDivergence(0.0) P Q
+    @test_colwise RenyiDivergence(1.0) P Q
+    @test_colwise RenyiDivergence(Inf) P Q
+    @test_colwise RenyiDivergence(0.5) P Q
+    @test_colwise RenyiDivergence(2) P Q
+    @test_colwise RenyiDivergence(10) P Q
+    @test_colwise JSDivergence() P Q
+    @test_colwise SpanNormDist() X Y
 
-@test_colwise BhattacharyyaDist() X Y
-@test_colwise HellingerDist() X Y
+    @test_colwise BhattacharyyaDist() X Y
+    @test_colwise HellingerDist() X Y
 
-w = rand(m)
+    w = rand(m)
 
-@test_colwise WeightedSqEuclidean(w) X Y
-@test_colwise WeightedEuclidean(w) X Y
-@test_colwise WeightedCityblock(w) X Y
-@test_colwise WeightedMinkowski(w, 2.5) X Y
-@test_colwise WeightedHamming(w) A B
+    @test_colwise WeightedSqEuclidean(w) X Y
+    @test_colwise WeightedEuclidean(w) X Y
+    @test_colwise WeightedCityblock(w) X Y
+    @test_colwise WeightedMinkowski(w, 2.5) X Y
+    @test_colwise WeightedHamming(w) A B
 
-Q = rand(m, m)
-Q = Q * Q'  # make sure Q is positive-definite
+    Q = rand(m, m)
+    Q = Q * Q'  # make sure Q is positive-definite
 
-@test_colwise SqMahalanobis(Q) X Y
-@test_colwise Mahalanobis(Q) X Y
+    @test_colwise SqMahalanobis(Q) X Y
+    @test_colwise Mahalanobis(Q) X Y
 
 end # testset
 
@@ -428,70 +428,70 @@ end
 
 @testset "pairwise metrics" begin
 
-m = 5
-n = 8
-nx = 6
-ny = 8
+    m = 5
+    n = 8
+    nx = 6
+    ny = 8
 
-X = rand(m, nx)
-Y = rand(m, ny)
-A = rand(1:3, m, nx)
-B = rand(1:3, m, ny)
+    X = rand(m, nx)
+    Y = rand(m, ny)
+    A = rand(1:3, m, nx)
+    B = rand(1:3, m, ny)
 
-P = rand(m, nx)
-Q = rand(m, ny)
+    P = rand(m, nx)
+    Q = rand(m, ny)
 
 
-@test_pairwise SqEuclidean() X Y
-@test_pairwise Euclidean() X Y
-@test_pairwise Cityblock() X Y
-@test_pairwise Chebyshev() X Y
-@test_pairwise Minkowski(2.5) X Y
-@test_pairwise Hamming() A B
+    @test_pairwise SqEuclidean() X Y
+    @test_pairwise Euclidean() X Y
+    @test_pairwise Cityblock() X Y
+    @test_pairwise Chebyshev() X Y
+    @test_pairwise Minkowski(2.5) X Y
+    @test_pairwise Hamming() A B
 
-@test_pairwise CosineDist() X Y
-@test_pairwise CorrDist() X Y
+    @test_pairwise CosineDist() X Y
+    @test_pairwise CorrDist() X Y
 
-@test_pairwise ChiSqDist() X Y
-@test_pairwise KLDivergence() P Q
-@test_pairwise RenyiDivergence(0.0) P Q
-@test_pairwise RenyiDivergence(1.0) P Q
-@test_pairwise RenyiDivergence(Inf) P Q
-@test_pairwise RenyiDivergence(0.5) P Q
-@test_pairwise RenyiDivergence(2) P Q
-@test_pairwise JSDivergence() P Q
+    @test_pairwise ChiSqDist() X Y
+    @test_pairwise KLDivergence() P Q
+    @test_pairwise RenyiDivergence(0.0) P Q
+    @test_pairwise RenyiDivergence(1.0) P Q
+    @test_pairwise RenyiDivergence(Inf) P Q
+    @test_pairwise RenyiDivergence(0.5) P Q
+    @test_pairwise RenyiDivergence(2) P Q
+    @test_pairwise JSDivergence() P Q
 
-@test_pairwise BhattacharyyaDist() X Y
-@test_pairwise HellingerDist() X Y
+    @test_pairwise BhattacharyyaDist() X Y
+    @test_pairwise HellingerDist() X Y
 
-w = rand(m)
+    w = rand(m)
 
-@test_pairwise WeightedSqEuclidean(w) X Y
-@test_pairwise WeightedEuclidean(w) X Y
-@test_pairwise WeightedCityblock(w) X Y
-@test_pairwise WeightedMinkowski(w, 2.5) X Y
-@test_pairwise WeightedHamming(w) A B
+    @test_pairwise WeightedSqEuclidean(w) X Y
+    @test_pairwise WeightedEuclidean(w) X Y
+    @test_pairwise WeightedCityblock(w) X Y
+    @test_pairwise WeightedMinkowski(w, 2.5) X Y
+    @test_pairwise WeightedHamming(w) A B
 
-Q = rand(m, m)
-Q = Q * Q'  # make sure Q is positive-definite
+    Q = rand(m, m)
+    Q = Q * Q'  # make sure Q is positive-definite
 
-@test_pairwise SqMahalanobis(Q) X Y
-@test_pairwise Mahalanobis(Q) X Y
+    @test_pairwise SqMahalanobis(Q) X Y
+    @test_pairwise Mahalanobis(Q) X Y
 
 end #testset
 
 @testset "Euclidean precision" begin
-X = [0.1 0.2; 0.3 0.4; -0.1 -0.1]
-pd = pairwise(Euclidean(1e-12), X, X)
-@test pd[1,1] == 0
-@test pd[2,2] == 0
-pd = pairwise(Euclidean(1e-12), X)
-@test pd[1,1] == 0
-@test pd[2,2] == 0
-pd = pairwise(SqEuclidean(1e-12), X, X)
-@test pd[1,1] == 0
-@test pd[2,2] == 0
-pd = pairwise(SqEuclidean(1e-12), X)
-@test pd[1,1] == 0
-@test pd[2,2] == 0
+    X = [0.1 0.2; 0.3 0.4; -0.1 -0.1]
+    pd = pairwise(Euclidean(1e-12), X, X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
+    pd = pairwise(Euclidean(1e-12), X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
+    pd = pairwise(SqEuclidean(1e-12), X, X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
+    pd = pairwise(SqEuclidean(1e-12), X)
+    @test pd[1,1] == 0
+    @test pd[2,2] == 0
 end

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -1,10 +1,5 @@
 # Unit tests for Distances
 
-# Unfortunately small non-zero numbers (~10^-16) are appearing
-# in our tests due to accumulating floating point rounding errors - we either
-# need to allow small errors in our tests or change the way we do accumulations
-approxcomp(x::Real, comp, y::Real) = comp(x, y) || (x + one(x) ≈ y + one(y))
-
 macro test_metricity(_dist, _x, _y, _z)
     quote
         dist = $(esc(_dist))
@@ -15,26 +10,30 @@ macro test_metricity(_dist, _x, _y, _z)
         dxz = evaluate(dist, x, z)
         dyz = evaluate(dist, y, z)
         if (isa(dist, PreMetric))
-          @test approxcomp(evaluate(dist, x, x), ==, zero(eltype(x)))
-          @test approxcomp(evaluate(dist, y, y), ==, zero(eltype(x)))
-          @test approxcomp(evaluate(dist, z, z), ==, zero(eltype(x)))
-          @test approxcomp(dxy, ≥, zero(eltype(x)))
-          @test approxcomp(dxz, ≥, zero(eltype(x)))
-          @test approxcomp(dyz, ≥, zero(eltype(x)))
+          # Unfortunately small non-zero numbers (~10^-16) are appearing
+          # in our tests due to accumulating floating point rounding errors.
+          # We either need to allow small errors in our tests or change the
+          # way we do accumulations...
+          @test evaluate(dist, x, x) ≈ zero(eltype(x))
+          @test evaluate(dist, y, y) ≈ zero(eltype(y))
+          @test evaluate(dist, z, z) ≈ zero(eltype(z))
+          @test dxy ≥ zero(eltype(x))
+          @test dxz ≥ zero(eltype(x))
+          @test dyz ≥ zero(eltype(x))
         end
         if (isa(dist, SemiMetric))
           @test dxy ≈ evaluate(dist, y, x)
           @test dxz ≈ evaluate(dist, z, x)
           @test dyz ≈ evaluate(dist, y, z)
         else # Not symmetric, so more PreMetric tests
-          @test approxcomp(evaluate(dist, y, x), ≥, zero(eltype(x)))
-          @test approxcomp(evaluate(dist, z, x), ≥, zero(eltype(x)))
-          @test approxcomp(evaluate(dist, z, y), ≥, zero(eltype(x)))
+          @test evaluate(dist, y, x) ≥ zero(eltype(x))
+          @test evaluate(dist, z, x) ≥ zero(eltype(x))
+          @test evaluate(dist, z, y) ≥ zero(eltype(x))
         end
         if (isa(dist, Metric))
-          @test approxcomp(dxz, ≤, dxy + dyz)
-          @test approxcomp(dyz, ≤, evaluate(dist, y, x) + dxz)
-          @test approxcomp(dxy, ≤, dxz + evaluate(dist, z, y))
+          @test dxz ≤ dxy + dyz
+          @test dyz ≤ evaluate(dist, y, x) + dxz
+          @test dxy ≤ dxz + evaluate(dist, z, y)
         end
     end
 end
@@ -82,9 +81,6 @@ p = rand(m)
 q = rand(m)
 r = rand(m)
 p[p .< median(p)] = 0
-p /= sum(p)
-q /= sum(q)
-r /= sum(r)
 p /= sum(p)
 q /= sum(q)
 r /= sum(r)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -370,8 +370,10 @@ B = rand(1:3, m, n)
 
 P = rand(m, n)
 Q = rand(m, n)
-P[P .< median(P)] = 0.0
-
+# Make sure not to remove all of the non-zeros from any column
+for i in 1:n
+  P[P[:, i] .< median(P[:, i])/2, i] = 0.0
+end
 
 @test_colwise SqEuclidean() X Y
 @test_colwise Euclidean() X Y

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -31,9 +31,12 @@ macro test_metricity(_dist, _x, _y, _z)
             @test evaluate(dist, z, y) ≥ zero(eltype(x))
         end
         if isa(dist, Metric)
-            @test dxz ≤ dxy + dyz
-            @test dyz ≤ evaluate(dist, y, x) + dxz
-            @test dxy ≤ dxz + evaluate(dist, z, y)
+            # Again we have small rounding errors in accumulations
+            @test dxz ≤ dxy + dyz || dxz ≈ dxy + dyz
+            dyx = evaluate(dist, y, x)
+            @test dyz ≤ dyx + dxz || dyz ≈ dyx + dxz
+            dzy = evaluate(dist, z, y)
+            @test dxy ≤ dxz + dzy || dxy ≈ dxz + dzy
         end
     end
 end

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -257,6 +257,18 @@ a = [1, 0]; b = [2.0] ; w = [3.0]
 @test_throws DimensionMismatch wsqeuclidean(a, b, w)
 a = [1, 0]; b = [2.0, 4.0] ; w = [3.0]
 @test_throws DimensionMismatch wsqeuclidean(a, b, w)
+p = [0.5, 0.5]; q = [0.3, 0.3, 0.4]
+@test_throws DimensionMismatch bhattacharyya(p, q)
+@test_throws DimensionMismatch hellinger(q, p)
+Q = rand(length(p), length(p))
+Q = Q * Q'  # make sure Q is positive-definite
+@test_throws DimensionMismatch mahalanobis(p, q, Q)
+@test_throws DimensionMismatch mahalanobis(q, q, Q)
+mat23 = [0.3 0.2 0.0; 0.1 0.0 0.4]
+mat22 = [0.3 0.2; 0.1 0.4]
+@test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat23)
+@test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, q)
+@test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat22)
 
 end # testset
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -103,22 +103,22 @@ end
 
 a = 1
 b = 2
-@test sqeuclidean(a, a) == 0.
-@test sqeuclidean(a, b) == 1.
+@test sqeuclidean(a, a) == 0.0
+@test sqeuclidean(a, b) == 1.0
 
-@test euclidean(a, a) == 0.
-@test euclidean(a, b) == 1.
+@test euclidean(a, a) == 0.0
+@test euclidean(a, b) == 1.0
 
-@test cityblock(a, a) == 0.
-@test cityblock(a, b) == 1.
+@test cityblock(a, a) == 0.0
+@test cityblock(a, b) == 1.0
 
-@test chebyshev(a, a) == 0.
-@test chebyshev(a, b) == 1.
+@test chebyshev(a, a) == 0.0
+@test chebyshev(a, b) == 1.0
 
-@test chebyshev(a, a) == 0.
+@test chebyshev(a, a) == 0.0
 
-@test minkowski(a, a, 2) == 0.
-@test minkowski(a, b, 2) == 1.
+@test minkowski(a, a, 2) == 0.0
+@test minkowski(a, b, 2) == 1.0
 
 @test hamming(a, a) == 0
 @test hamming(a, b) == 1
@@ -126,31 +126,31 @@ b = 2
 bt = [true, false, true]
 bf = [false, true, true]
 @test rogerstanimoto(bt, bt) == 0
-@test rogerstanimoto(bt, bf) == 4./5
+@test rogerstanimoto(bt, bf) == 4.0/5.0
 
-for (x, y) in (([4., 5., 6., 7.], [3., 9., 8., 1.]),
-                ([4., 5., 6., 7.], [3. 8.; 9. 1.]))
-    @test sqeuclidean(x, x) == 0.
+for (x, y) in (([4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]),
+                ([4.0, 5.0, 6.0, 7.0], [3. 8.; 9. 1.0]))
+    @test sqeuclidean(x, x) == 0.0
     @test sqeuclidean(x, y) == 57.
 
-    @test euclidean(x, x) == 0.
-    @test euclidean(x, y) == sqrt(57.)
+    @test euclidean(x, x) == 0.0
+    @test euclidean(x, y) == sqrt(57.0)
 
     @test jaccard(x, x) == 0
     @test jaccard(x, y) == 13./28
 
-    @test cityblock(x, x) == 0.
-    @test cityblock(x, y) == 13.
+    @test cityblock(x, x) == 0.0
+    @test cityblock(x, y) == 13.0
 
-    @test chebyshev(x, x) == 0.
-    @test chebyshev(x, y) == 6.
+    @test chebyshev(x, x) == 0.0
+    @test chebyshev(x, y) == 6.0
 
-    @test minkowski(x, x, 2) == 0.
-    @test minkowski(x, y, 2) == sqrt(57.)
+    @test minkowski(x, x, 2) == 0.0
+    @test minkowski(x, y, 2) == sqrt(57.0)
 
     @test cosine_dist(x, x) ≈ 0.0
 
-    @test_throws DimensionMismatch cosine_dist(1.:2, 1.:3)
+    @test_throws DimensionMismatch cosine_dist(1.0:2, 1.0:3)
     @test cosine_dist(x, y) ≈ (1.0 - 112. / sqrt(19530.))
     x_int, y_int = map(Int64, x), map(Int64, y)
     @test cosine_dist(x_int, y_int) == (1.0 - 112. / sqrt(19530.))
@@ -158,10 +158,10 @@ for (x, y) in (([4., 5., 6., 7.], [3., 9., 8., 1.]),
     @test corr_dist(x, x) < 1.0e-14
     @test corr_dist(x, y) ≈ cosine_dist(x .- mean(x), vec(y) .- mean(y))
 
-    @test chisq_dist(x, x) == 0.
+    @test chisq_dist(x, x) == 0.0
     @test chisq_dist(x, y) == sum((x - vec(y)).^2 ./ (x + vec(y)))
 
-    @test spannorm_dist(x, x) == 0.
+    @test spannorm_dist(x, x) == 0.0
     @test spannorm_dist(x, y) == maximum(x - vec(y)) - minimum(x - vec(y))
 
 
@@ -172,25 +172,25 @@ for (x, y) in (([4., 5., 6., 7.], [3., 9., 8., 1.]),
 
     w = rand(size(x))
 
-    @test wsqeuclidean(x, x, w) == 0.
+    @test wsqeuclidean(x, x, w) == 0.0
     @test wsqeuclidean(x, y, w) ≈ dot((x - vec(y)).^2, w)
 
-    @test weuclidean(x, x, w) == 0.
+    @test weuclidean(x, x, w) == 0.0
     @test weuclidean(x, y, w) == sqrt(wsqeuclidean(x, y, w))
 
-    @test wcityblock(x, x, w) == 0.
+    @test wcityblock(x, x, w) == 0.0
     @test wcityblock(x, y, w) ≈ dot(abs.(x - vec(y)), w)
 
-    @test wminkowski(x, x, w, 2) == 0.
+    @test wminkowski(x, x, w, 2) == 0.0
     @test wminkowski(x, y, w, 2) ≈ weuclidean(x, y, w)
 end
 
 # Test weighted Hamming distances with even weights
-a = [1., 2., 1., 3., 2., 1.]
-b = [1., 3., 0., 2., 2., 0.]
+a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
+b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
 w = rand(size(a))
 
-@test whamming(a, a, w) == 0.
+@test whamming(a, a, w) == 0.0
 @test whamming(a, b, w) == sum((a .!= b) .* w)
 
 # Minimal test of Jaccard - test return type stability.
@@ -207,7 +207,7 @@ p /= sum(p)
 q = rand(12)
 q /= sum(q)
 
-klv = 0.
+klv = 0.0
 for i = 1 : length(p)
     if p[i] > 0
         klv += p[i] * log(p[i] / q[i])
@@ -252,15 +252,15 @@ end #testset
 
 a = Float64[]
 b = Float64[]
-@test sqeuclidean(a, b) == 0.
+@test sqeuclidean(a, b) == 0.0
 @test isa(sqeuclidean(a, b), Float64)
-@test euclidean(a, b) == 0.
+@test euclidean(a, b) == 0.0
 @test isa(euclidean(a, b), Float64)
-@test cityblock(a, b) == 0.
+@test cityblock(a, b) == 0.0
 @test isa(cityblock(a, b), Float64)
-@test chebyshev(a, b) == 0
+@test chebyshev(a, b) == 0.0
 @test isa(chebyshev(a, b), Float64)
-@test minkowski(a, b, 2) == 0.
+@test minkowski(a, b, 2) == 0.0
 @test isa(minkowski(a, b, 2), Float64)
 @test hamming(a, b) == 0.0
 @test isa(hamming(a, b), Int)
@@ -287,16 +287,16 @@ end # testset
 
 @testset "mahalanobis" begin
 
-x, y = [4., 5., 6., 7.], [3., 9., 8., 1.]
-a = [1., 2., 1., 3., 2., 1.]
-b = [1., 3., 0., 2., 2., 0.]
+x, y = [4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]
+a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
+b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
 
 Q = rand(length(x), length(x))
 Q = Q * Q'  # make sure Q is positive-definite
-@test sqmahalanobis(x, x, Q) == 0.
+@test sqmahalanobis(x, x, Q) == 0.0
 @test sqmahalanobis(x, y, Q) ≈ dot(x - y, Q * (x - y))
 
-@test mahalanobis(x, x, Q) == 0.
+@test mahalanobis(x, x, Q) == 0.0
 @test mahalanobis(x, y, Q) == sqrt(sqmahalanobis(x, y, Q))
 
 end #testset
@@ -304,9 +304,9 @@ end #testset
 
 @testset "bhattacharyya / hellinger" begin
 
-x, y = [4., 5., 6., 7.], [3., 9., 8., 1.]
-a = [1., 2., 1., 3., 2., 1.]
-b = [1., 3., 0., 2., 2., 0.]
+x, y = [4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]
+a = [1.0, 2.0, 1.0, 3.0, 2.0, 1.0]
+b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
 p = rand(12)
 p[p .< median(p)] = 0.0
 q = rand(12)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -14,9 +14,9 @@ macro test_metricity(_dist, _x, _y, _z)
           # in our tests due to accumulating floating point rounding errors.
           # We either need to allow small errors in our tests or change the
           # way we do accumulations...
-          @test evaluate(dist, x, x) ≈ zero(eltype(x))
-          @test evaluate(dist, y, y) ≈ zero(eltype(y))
-          @test evaluate(dist, z, z) ≈ zero(eltype(z))
+          @test evaluate(dist, x, x) + one(eltype(x)) ≈ one(eltype(x))
+          @test evaluate(dist, y, y) + one(eltype(y)) ≈ one(eltype(y))
+          @test evaluate(dist, z, z) + one(eltype(z)) ≈ one(eltype(z))
           @test dxy ≥ zero(eltype(x))
           @test dxz ≥ zero(eltype(x))
           @test dyz ≥ zero(eltype(x))

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -40,30 +40,42 @@ end
 
 @testset "PreMetric, SemiMetric, Metric" begin
 
-m = 10
-x = rand(m)
-y = rand(m)
-z = rand(m)
-a = rand(1:3, m)
-b = rand(1:3, m)
-c = rand(1:3, m)
+n = 10
+x = rand(n)
+y = rand(n)
+z = rand(n)
 
 @test_metricity SqEuclidean() x y z
 @test_metricity Euclidean() x y z
 @test_metricity Cityblock() x y z
 @test_metricity Chebyshev() x y z
 @test_metricity Minkowski(2.5) x y z
-@test_metricity Hamming() a b c
 
 @test_metricity CosineDist() x y z
 @test_metricity CorrDist() x y z
 
 @test_metricity ChiSqDist() x y z
 
+@test_metricity Jaccard() x y z
+@test_metricity SpanNormDist() x y z
+
 @test_metricity BhattacharyyaDist() x y z
 @test_metricity HellingerDist() x y z
 
-w = rand(m)
+k = rand(1:3, n)
+l = rand(1:3, n)
+m = rand(1:3, n)
+
+@test_metricity Hamming() k l m
+
+a = rand(Bool, n)
+b = rand(Bool, n)
+c = rand(Bool, n)
+
+@test_metricity RogersTanimoto() a b c
+@test_metricity Jaccard() a b c
+
+w = rand(n)
 
 @test_metricity WeightedSqEuclidean(w) x y z
 @test_metricity WeightedEuclidean(w) x y z
@@ -71,15 +83,15 @@ w = rand(m)
 @test_metricity WeightedMinkowski(w, 2.5) x y z
 @test_metricity WeightedHamming(w) a b c
 
-Q = rand(m, m)
+Q = rand(n, n)
 Q = Q * Q'  # make sure Q is positive-definite
 
 @test_metricity SqMahalanobis(Q) x y z
 @test_metricity Mahalanobis(Q) x y z
 
-p = rand(m)
-q = rand(m)
-r = rand(m)
+p = rand(n)
+q = rand(n)
+r = rand(n)
 p[p .< median(p)] = 0
 p /= sum(p)
 q /= sum(q)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -91,6 +91,7 @@ r /= sum(r)
 @test_metricity RenyiDivergence(Inf) p q r
 @test_metricity RenyiDivergence(0.5) p q r
 @test_metricity RenyiDivergence(2) p q r
+@test_metricity RenyiDivergence(10) p q r
 @test_metricity JSDivergence() p q r
 
 end
@@ -186,6 +187,7 @@ end
 
 @test renyi_divergence(p, r, 0) ≈ -log(scale)
 @test renyi_divergence(p, r, 1) ≈ -log(scale)
+@test renyi_divergence(p, r, 10) ≈ -log(scale)
 @test renyi_divergence(p, r, rand()) ≈ -log(scale)
 @test renyi_divergence(p, r, Inf) ≈ -log(scale)
 @test isinf(renyi_divergence([0.0, 0.5, 0.5], [0.0, 1.0, 0.0], Inf))
@@ -206,7 +208,6 @@ a = [NaN, 0]; b = [0, NaN]
 @test isnan(chebyshev(a, b)) == isnan(maximum(a-b))
 a = [NaN, 0]; b = [0, 1]
 @test isnan(chebyshev(a, b)) == isnan(maximum(a-b))
-@test !isnan(renyi_divergence([0.5, 0.0, 0.5], [0.5, NaN, 0.5], 2))
 @test isnan(renyi_divergence([0.5, 0.0, 0.5], [0.5, 0.5, NaN], 2))
 end #testset
 
@@ -357,6 +358,7 @@ end
 @test_colwise RenyiDivergence(Inf) P Q
 @test_colwise RenyiDivergence(0.5) P Q
 @test_colwise RenyiDivergence(2) P Q
+@test_colwise RenyiDivergence(10) P Q
 @test_colwise JSDivergence() P Q
 @test_colwise SpanNormDist() X Y
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -122,7 +122,6 @@ end
 
     bt = [true, false, true]
     bf = [false, true, true]
-    @test rogerstanimoto(bt, bt) == 0
     @test rogerstanimoto(bt, bf) == 4.0/5.0
 
     for (x, y) in (([4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]),

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -10,30 +10,30 @@ macro test_metricity(_dist, _x, _y, _z)
         dxz = evaluate(dist, x, z)
         dyz = evaluate(dist, y, z)
         if (isa(dist, PreMetric))
-          # Unfortunately small non-zero numbers (~10^-16) are appearing
-          # in our tests due to accumulating floating point rounding errors.
-          # We either need to allow small errors in our tests or change the
-          # way we do accumulations...
-          @test evaluate(dist, x, x) + one(eltype(x)) ≈ one(eltype(x))
-          @test evaluate(dist, y, y) + one(eltype(y)) ≈ one(eltype(y))
-          @test evaluate(dist, z, z) + one(eltype(z)) ≈ one(eltype(z))
-          @test dxy ≥ zero(eltype(x))
-          @test dxz ≥ zero(eltype(x))
-          @test dyz ≥ zero(eltype(x))
+            # Unfortunately small non-zero numbers (~10^-16) are appearing
+            # in our tests due to accumulating floating point rounding errors.
+            # We either need to allow small errors in our tests or change the
+            # way we do accumulations...
+            @test evaluate(dist, x, x) + one(eltype(x)) ≈ one(eltype(x))
+            @test evaluate(dist, y, y) + one(eltype(y)) ≈ one(eltype(y))
+            @test evaluate(dist, z, z) + one(eltype(z)) ≈ one(eltype(z))
+            @test dxy ≥ zero(eltype(x))
+            @test dxz ≥ zero(eltype(x))
+            @test dyz ≥ zero(eltype(x))
         end
         if (isa(dist, SemiMetric))
-          @test dxy ≈ evaluate(dist, y, x)
-          @test dxz ≈ evaluate(dist, z, x)
-          @test dyz ≈ evaluate(dist, y, z)
+            @test dxy ≈ evaluate(dist, y, x)
+            @test dxz ≈ evaluate(dist, z, x)
+            @test dyz ≈ evaluate(dist, y, z)
         else # Not symmetric, so more PreMetric tests
-          @test evaluate(dist, y, x) ≥ zero(eltype(x))
-          @test evaluate(dist, z, x) ≥ zero(eltype(x))
-          @test evaluate(dist, z, y) ≥ zero(eltype(x))
+            @test evaluate(dist, y, x) ≥ zero(eltype(x))
+            @test evaluate(dist, z, x) ≥ zero(eltype(x))
+            @test evaluate(dist, z, y) ≥ zero(eltype(x))
         end
         if (isa(dist, Metric))
-          @test dxz ≤ dxy + dyz
-          @test dyz ≤ evaluate(dist, y, x) + dxz
-          @test dxy ≤ dxz + evaluate(dist, z, y)
+            @test dxz ≤ dxy + dyz
+            @test dyz ≤ evaluate(dist, y, x) + dxz
+            @test dxy ≤ dxz + evaluate(dist, z, y)
         end
     end
 end
@@ -126,7 +126,7 @@ bf = [false, true, true]
 @test rogerstanimoto(bt, bf) == 4.0/5.0
 
 for (x, y) in (([4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]),
-                ([4.0, 5.0, 6.0, 7.0], [3. 8.; 9. 1.0]))
+               ([4.0, 5.0, 6.0, 7.0], [3. 8.; 9. 1.0]))
     @test sqeuclidean(x, y) == 57.0
 
     @test euclidean(x, y) == sqrt(57.0)
@@ -362,7 +362,7 @@ P = rand(m, n)
 Q = rand(m, n)
 # Make sure not to remove all of the non-zeros from any column
 for i in 1:n
-  P[P[:, i] .< median(P[:, i])/2, i] = 0.0
+    P[P[:, i] .< median(P[:, i])/2, i] = 0.0
 end
 
 @test_colwise SqEuclidean() X Y
@@ -481,17 +481,17 @@ Q = Q * Q'  # make sure Q is positive-definite
 end #testset
 
 @testset "Euclidean precision" begin
-    X = [0.1 0.2; 0.3 0.4; -0.1 -0.1]
-    pd = pairwise(Euclidean(1e-12), X, X)
-    @test pd[1,1] == 0
-    @test pd[2,2] == 0
-    pd = pairwise(Euclidean(1e-12), X)
-    @test pd[1,1] == 0
-    @test pd[2,2] == 0
-    pd = pairwise(SqEuclidean(1e-12), X, X)
-    @test pd[1,1] == 0
-    @test pd[2,2] == 0
-    pd = pairwise(SqEuclidean(1e-12), X)
-    @test pd[1,1] == 0
-    @test pd[2,2] == 0
+X = [0.1 0.2; 0.3 0.4; -0.1 -0.1]
+pd = pairwise(Euclidean(1e-12), X, X)
+@test pd[1,1] == 0
+@test pd[2,2] == 0
+pd = pairwise(Euclidean(1e-12), X)
+@test pd[1,1] == 0
+@test pd[2,2] == 0
+pd = pairwise(SqEuclidean(1e-12), X, X)
+@test pd[1,1] == 0
+@test pd[2,2] == 0
+pd = pairwise(SqEuclidean(1e-12), X)
+@test pd[1,1] == 0
+@test pd[2,2] == 0
 end

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -101,7 +101,7 @@ w = rand(size(a))
 
 # Test KL, Renyi and JS divergences
 p = r = rand(12)
-p[p .< 0.3] = 0.0
+p[p .< maximum(p) / 2] = 0.0
 scale = sum(p) / sum(r)
 r /= sum(r)
 p /= sum(p)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -99,24 +99,12 @@ end
 
 a = 1
 b = 2
-@test sqeuclidean(a, a) == 0.0
 @test sqeuclidean(a, b) == 1.0
 
-@test euclidean(a, a) == 0.0
 @test euclidean(a, b) == 1.0
-
-@test cityblock(a, a) == 0.0
 @test cityblock(a, b) == 1.0
-
-@test chebyshev(a, a) == 0.0
 @test chebyshev(a, b) == 1.0
-
-@test chebyshev(a, a) == 0.0
-
-@test minkowski(a, a, 2) == 0.0
 @test minkowski(a, b, 2) == 1.0
-
-@test hamming(a, a) == 0
 @test hamming(a, b) == 1
 
 bt = [true, false, true]
@@ -126,38 +114,27 @@ bf = [false, true, true]
 
 for (x, y) in (([4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]),
                 ([4.0, 5.0, 6.0, 7.0], [3. 8.; 9. 1.0]))
-    @test sqeuclidean(x, x) == 0.0
-    @test sqeuclidean(x, y) == 57.
+    @test sqeuclidean(x, y) == 57.0
 
-    @test euclidean(x, x) == 0.0
     @test euclidean(x, y) == sqrt(57.0)
 
-    @test jaccard(x, x) == 0
-    @test jaccard(x, y) == 13./28
+    @test jaccard(x, y) == 13.0/28
 
-    @test cityblock(x, x) == 0.0
     @test cityblock(x, y) == 13.0
 
-    @test chebyshev(x, x) == 0.0
     @test chebyshev(x, y) == 6.0
 
-    @test minkowski(x, x, 2) == 0.0
     @test minkowski(x, y, 2) == sqrt(57.0)
 
-    @test cosine_dist(x, x) ≈ 0.0
-
     @test_throws DimensionMismatch cosine_dist(1.0:2, 1.0:3)
-    @test cosine_dist(x, y) ≈ (1.0 - 112. / sqrt(19530.))
+    @test cosine_dist(x, y) ≈ (1.0 - 112. / sqrt(19530.0))
     x_int, y_int = map(Int64, x), map(Int64, y)
-    @test cosine_dist(x_int, y_int) == (1.0 - 112. / sqrt(19530.))
+    @test cosine_dist(x_int, y_int) == (1.0 - 112.0 / sqrt(19530.0))
 
-    @test corr_dist(x, x) < 1.0e-14
     @test corr_dist(x, y) ≈ cosine_dist(x .- mean(x), vec(y) .- mean(y))
 
-    @test chisq_dist(x, x) == 0.0
     @test chisq_dist(x, y) == sum((x - vec(y)).^2 ./ (x + vec(y)))
 
-    @test spannorm_dist(x, x) == 0.0
     @test spannorm_dist(x, y) == maximum(x - vec(y)) - minimum(x - vec(y))
 
 
@@ -168,16 +145,12 @@ for (x, y) in (([4.0, 5.0, 6.0, 7.0], [3.0, 9.0, 8.0, 1.0]),
 
     w = rand(size(x))
 
-    @test wsqeuclidean(x, x, w) == 0.0
     @test wsqeuclidean(x, y, w) ≈ dot((x - vec(y)).^2, w)
 
-    @test weuclidean(x, x, w) == 0.0
     @test weuclidean(x, y, w) == sqrt(wsqeuclidean(x, y, w))
 
-    @test wcityblock(x, x, w) == 0.0
     @test wcityblock(x, y, w) ≈ dot(abs.(x - vec(y)), w)
 
-    @test wminkowski(x, x, w, 2) == 0.0
     @test wminkowski(x, y, w, 2) ≈ weuclidean(x, y, w)
 end
 
@@ -211,11 +184,6 @@ for i = 1 : length(p)
 end
 @test kl_divergence(p, q) ≈ klv
 
-@test renyi_divergence(p, p, 0) ≈ 0
-@test renyi_divergence(p, p, 1) ≈ 0
-@test renyi_divergence(p, p, rand()) ≈ 0
-@test renyi_divergence(p, p, 1.0 + rand()) ≈ 0
-@test renyi_divergence(p, p, Inf) ≈ 0
 @test renyi_divergence(p, r, 0) ≈ -log(scale)
 @test renyi_divergence(p, r, 1) ≈ -log(scale)
 @test renyi_divergence(p, r, rand()) ≈ -log(scale)
@@ -226,7 +194,6 @@ end
 
 pm = (p + q) / 2
 jsv = kl_divergence(p, pm) / 2 + kl_divergence(q, pm) / 2
-@test js_divergence(p, p) ≈ 0.0
 @test js_divergence(p, q) ≈ jsv
 
 
@@ -289,10 +256,8 @@ b = [1.0, 3.0, 0.0, 2.0, 2.0, 0.0]
 
 Q = rand(length(x), length(x))
 Q = Q * Q'  # make sure Q is positive-definite
-@test sqmahalanobis(x, x, Q) == 0.0
 @test sqmahalanobis(x, y, Q) ≈ dot(x - y, Q * (x - y))
 
-@test mahalanobis(x, x, Q) == 0.0
 @test mahalanobis(x, y, Q) == sqrt(sqmahalanobis(x, y, Q))
 
 end #testset

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -200,7 +200,7 @@ w = rand(size(a))
 
 # Test KL, Renyi and JS divergences
 p = r = rand(12)
-p[p .< maximum(p) / 2] = 0.0
+p[p .< median(p)] = 0.0
 scale = sum(p) / sum(r)
 r /= sum(r)
 p /= sum(p)
@@ -308,7 +308,7 @@ x, y = [4., 5., 6., 7.], [3., 9., 8., 1.]
 a = [1., 2., 1., 3., 2., 1.]
 b = [1., 3., 0., 2., 2., 0.]
 p = rand(12)
-p[p .< 0.3] = 0.
+p[p .< median(p)] = 0.0
 q = rand(12)
 
 # Bhattacharyya and Hellinger distances are defined for discrete
@@ -374,7 +374,7 @@ B = rand(1:3, m, n)
 
 P = rand(m, n)
 Q = rand(m, n)
-P[P .< 0.3] = 0.
+P[P .< median(P)] = 0.0
 
 
 @test_colwise SqEuclidean() X Y


### PR DESCRIPTION
I've noticed while working on #58 that there is a fairly ad hoc testing of whether the subtyping is correct for the distance measures defined here - there is much testing of equality to zero for self-distances, but not symmetry (for `SemiMetric`s) and the triangle inequality (for `Metric`s). I've introduced a test `@test_metricity`, that checks what each distance is a subtype of and tests the appropriate conditions.

There is now a systematic test for each distance measure to check it does not overclaim it's "metricity" (it can't check for underclaiming, but that is a less serious problem). This exposed a series of problems to do with floating point rounding errors for `CorrDist`, `CosineDist` and `RenyiDivergence`. This kind of issue has been identified before (e.g. #13), which I have now fixed (for `RenyiDivergence`), or relaxed the zero equality constraints (for the others).

I then updated the benchmarks and cleaned up a lot of the other testing code to remove unnecessary tests and move to a standard Julia style as seen in the rest of the package (e.g. 1. -> 1.0). Is this useful to people?