### PR TITLE
Make distances autodiffable

### DIFF
--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -13,7 +13,7 @@ result_type{T}(::SqMahalanobis{T}, ::AbstractArray, ::AbstractArray) = T
 
 # SqMahalanobis
 
-function evaluate{T<:AbstractFloat}(dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractVector)
+function evaluate{T<:Real}(dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractVector)
     if length(a) != length(b)
         throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
     end
@@ -25,14 +25,14 @@ end
 
 sqmahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = evaluate(SqMahalanobis(Q), a, b)
 
-function colwise!{T<:AbstractFloat}(r::AbstractArray, dist::SqMahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
+function colwise!{T<:Real}(r::AbstractArray, dist::SqMahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
     Q = dist.qmat
     m, n = get_colwise_dims(size(Q, 1), r, a, b)
     z = a - b
     dot_percol!(r, Q * z, z)
 end
 
-function colwise!{T<:AbstractFloat}(r::AbstractArray, dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractMatrix)
+function colwise!{T<:Real}(r::AbstractArray, dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractMatrix)
     Q = dist.qmat
     m, n = get_colwise_dims(size(Q, 1), r, a, b)
     z = a .- b
@@ -40,7 +40,7 @@ function colwise!{T<:AbstractFloat}(r::AbstractArray, dist::SqMahalanobis{T}, a:
     dot_percol!(r, Q * z, z)
 end
 
-function pairwise!{T<:AbstractFloat}(r::AbstractMatrix, dist::SqMahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
+function pairwise!{T<:Real}(r::AbstractMatrix, dist::SqMahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
     Q = dist.qmat
     m, na, nb = get_pairwise_dims(size(Q, 1), r, a, b)
 
@@ -58,7 +58,7 @@ function pairwise!{T<:AbstractFloat}(r::AbstractMatrix, dist::SqMahalanobis{T}, 
     r
 end
 
-function pairwise!{T<:AbstractFloat}(r::AbstractMatrix, dist::SqMahalanobis{T}, a::AbstractMatrix)
+function pairwise!{T<:Real}(r::AbstractMatrix, dist::SqMahalanobis{T}, a::AbstractMatrix)
     Q = dist.qmat
     m, n = get_pairwise_dims(size(Q, 1), r, a)
 
@@ -81,24 +81,24 @@ end
 
 # Mahalanobis
 
-function evaluate{T<:AbstractFloat}(dist::Mahalanobis{T}, a::AbstractVector, b::AbstractVector)
+function evaluate{T<:Real}(dist::Mahalanobis{T}, a::AbstractVector, b::AbstractVector)
     sqrt(evaluate(SqMahalanobis(dist.qmat), a, b))
 end
 
 mahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = evaluate(Mahalanobis(Q), a, b)
 
-function colwise!{T<:AbstractFloat}(r::AbstractArray, dist::Mahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
+function colwise!{T<:Real}(r::AbstractArray, dist::Mahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
     sqrt!(colwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
-function colwise!{T<:AbstractFloat}(r::AbstractArray, dist::Mahalanobis{T}, a::AbstractVector, b::AbstractMatrix)
+function colwise!{T<:Real}(r::AbstractArray, dist::Mahalanobis{T}, a::AbstractVector, b::AbstractMatrix)
     sqrt!(colwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
-function pairwise!{T<:AbstractFloat}(r::AbstractMatrix, dist::Mahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
+function pairwise!{T<:Real}(r::AbstractMatrix, dist::Mahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix)
     sqrt!(pairwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
-function pairwise!{T<:AbstractFloat}(r::AbstractMatrix, dist::Mahalanobis{T}, a::AbstractMatrix)
+function pairwise!{T<:Real}(r::AbstractMatrix, dist::Mahalanobis{T}, a::AbstractMatrix)
     sqrt!(pairwise!(r, SqMahalanobis(dist.qmat), a))
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -241,11 +241,11 @@ chisq_dist(a::AbstractArray, b::AbstractArray) = evaluate(ChiSqDist(), a, b)
 kl_divergence(a::AbstractArray, b::AbstractArray) = evaluate(KLDivergence(), a, b)
 
 # RenyiDivergence
-function eval_start{T<:AbstractFloat}(::RenyiDivergence, a::AbstractArray{T}, b::AbstractArray{T})
+function eval_start{T<:Real}(::RenyiDivergence, a::AbstractArray{T}, b::AbstractArray{T})
     zero(T), zero(T), sum(a), sum(b)
 end
 
-@inline function eval_op{T<:AbstractFloat}(dist::RenyiDivergence, ai::T, bi::T)
+@inline function eval_op{T<:Real}(dist::RenyiDivergence, ai::T, bi::T)
     if ai == zero(T)
         return zero(T), zero(T), zero(T), zero(T)
     elseif dist.is_normal
@@ -259,7 +259,7 @@ end
     end
 end
 
-@inline function eval_reduce{T<:AbstractFloat}(dist::RenyiDivergence,
+@inline function eval_reduce{T<:Real}(dist::RenyiDivergence,
                                                s1::Tuple{T, T, T, T},
                                                s2::Tuple{T, T, T, T})
     if dist.is_inf
@@ -275,7 +275,7 @@ end
     end
 end
 
-function eval_end{T<:AbstractFloat}(dist::RenyiDivergence, s::Tuple{T, T, T, T})
+function eval_end{T<:Real}(dist::RenyiDivergence, s::Tuple{T, T, T, T})
     if dist.is_zero || dist.is_normal
         log(s[2] / s[1]) / dist.p + log(s[4] / s[3])
     elseif dist.is_one

--- a/src/wmetrics.jl
+++ b/src/wmetrics.jl
@@ -6,7 +6,7 @@
 #   Metric types
 #
 ###########################################################
-@compat const RealAbstractArray{T <: AbstractFloat} =  AbstractArray{T}
+@compat const RealAbstractArray{T <: Real} =  AbstractArray{T}
 
 
 immutable WeightedEuclidean{W <: RealAbstractArray} <: Metric

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+ForwardDiff


### PR DESCRIPTION
Basically I just changed the `AbstractFloat` types to `Real` for ForwardDiff and ReverseDiff compatibility. The tests still pass. Is there some reason to use the `AbstractFloat` type?

I just did the following quick check for AD functionality.
```julia
using Distances
import ForwardDiff
import ReverseDiff

X = rand(3, 10);
f(w) = sum(pairwise(WeightedSqEuclidean(w), X))
df(w) = ForwardDiff.gradient(f, w)
df2(w) = ReverseDiff.gradient(f, w)

df([1., 2., 3.])
df2([1., 2., 3.])
```
How do I verify that the AD is working properly? ReverseDiff documentation says that mutation of the input is not allowed. There are some updating assignments in the code, but as far as I know these are not mutations in Julia. Is it safe to assume that if I get results, they are correct (i.e. I wont get wrong results silently)?