### PR TITLE
Fix ChiSq distance around zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Each distance corresponds to a distance type. The type name and the correspondin
 |  Chebyshev           |  `chebyshev(x, y)`         | `max(abs(x - y))` |
 |  Minkowski           |  `minkowski(x, y, p)`      | `sum(abs(x - y).^p) ^ (1/p)` |
 |  Hamming             |  `hamming(k, l)`           | `sum(k .!= l)` |
-|  Rogers-Tanimoto     |  `rogerstanimoto(a, b)`    | `2(sum(a&!b) + sum(!a&b)) / (2(sum(a&!b) + sum(!a&b)) + sum(a&b) + sum(!a&!b))` |
+|  RogersTanimoto      |  `rogerstanimoto(a, b)`    | `2(sum(a&!b) + sum(!a&b)) / (2(sum(a&!b) + sum(!a&b)) + sum(a&b) + sum(!a&!b))` |
 |  Jaccard             |  `jaccard(x, y)`           | `1 - sum(min(x, y)) / sum(max(x, y))` |
 |  CosineDist          |  `cosine_dist(x, y)`       | `1 - dot(x, y) / (norm(x) * norm(y))` |
 |  CorrDist            |  `corr_dist(x, y)`         | `cosine_dist(x - mean(x), y - mean(y))` |

--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ Each distance corresponds to a distance type. The type name and the correspondin
 |  GenKLDivergence     |  `gkl_divergence(x, y)`    | `sum(p .* log(p ./ q) - p + q)` |
 |  RenyiDivergence     | `renyi_divergence(p, q, k)`| `log(sum( p .* (p ./ q) .^ (k - 1))) / (k - 1)` |
 |  JSDivergence        |  `js_divergence(p, q)`     | `KL(p, m) / 2 + KL(p, m) / 2 with m = (p + q) / 2` |
-|  SpanNormDist        |  `spannorm_dist(x, y)`     | `max(x - y) - min(x - y )` |
+|  SpanNormDist        |  `spannorm_dist(x, y)`     | `max(x - y) - min(x - y)` |
 |  BhattacharyyaDist   |  `bhattacharyya(x, y)`     | `-log(sum(sqrt(x .* y) / sqrt(sum(x) * sum(y)))` |
 |  HellingerDist       |  `hellinger(x, y) `        | `sqrt(1 - sum(sqrt(x .* y) / sqrt(sum(x) * sum(y))))` |
 |  Haversine           |  `haversine(x, y, r)`      | [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula) |
 |  Mahalanobis         |  `mahalanobis(x, y, Q)`    | `sqrt((x - y)' * Q * (x - y))` |
-|  SqMahalanobis       |  `sqmahalanobis(x, y, Q)`  | ` (x - y)' * Q * (x - y)`  |
+|  SqMahalanobis       |  `sqmahalanobis(x, y, Q)`  | `(x - y)' * Q * (x - y)` |
 |  MeanAbsDeviation    |  `meanad(x, y)`            | `mean(abs.(x - y))` |
 |  MeanSqDeviation     |  `msd(x, y)`               | `mean(abs2.(x - y))` |
 |  RMSDeviation        |  `rmsd(x, y)`              | `sqrt(msd(x, y))` |
@@ -194,9 +194,9 @@ julia> pairwise(Euclidean(1e-12), x, x)
 
 ## Benchmarks
 
-The implementation has been carefully optimized based on benchmarks. The script in `benchmark/benchmarks.jl` defines a benchmark suite 
-for a variety of distances, under column-wise and pairwise settings. 
- 
+The implementation has been carefully optimized based on benchmarks. The script in `benchmark/benchmarks.jl` defines a benchmark suite
+for a variety of distances, under column-wise and pairwise settings.
+
 Here are benchmarks obtained running Julia 0.6 on a computer with a quad-core Intel Core i5-2500K processor @ 3.3 GHz.
 The tables below can be replicated using the script in `benchmark/print_table.jl`.
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -239,7 +239,7 @@ corr_dist(a::AbstractArray, b::AbstractArray) = evaluate(CorrDist(), a, b)
 result_type(::CorrDist, a::AbstractArray, b::AbstractArray) = result_type(CosineDist(), a, b)
 
 # ChiSqDist
-@inline eval_op(::ChiSqDist, ai, bi) = abs2(ai - bi) / (ai + bi)
+@inline eval_op(::ChiSqDist, ai, bi) = ifelse(ai != bi, abs2(ai - bi) / (ai + bi), zero(ai))
 @inline eval_reduce(::ChiSqDist, s1, s2) = s1 + s2
 chisq_dist(a::AbstractArray, b::AbstractArray) = evaluate(ChiSqDist(), a, b)
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -239,7 +239,7 @@ corr_dist(a::AbstractArray, b::AbstractArray) = evaluate(CorrDist(), a, b)
 result_type(::CorrDist, a::AbstractArray, b::AbstractArray) = result_type(CosineDist(), a, b)
 
 # ChiSqDist
-@inline eval_op(::ChiSqDist, ai, bi) = ifelse(ai != bi, abs2(ai - bi) / (ai + bi), zero(ai))
+@inline eval_op(::ChiSqDist, ai, bi) = ifelse(ai != bi, abs2(ai - bi) / (ai + bi), zero(abs2(ai - bi) / (ai + bi)))
 @inline eval_reduce(::ChiSqDist, s1, s2) = s1 + s2
 chisq_dist(a::AbstractArray, b::AbstractArray) = evaluate(ChiSqDist(), a, b)
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -239,7 +239,7 @@ corr_dist(a::AbstractArray, b::AbstractArray) = evaluate(CorrDist(), a, b)
 result_type(::CorrDist, a::AbstractArray, b::AbstractArray) = result_type(CosineDist(), a, b)
 
 # ChiSqDist
-@inline eval_op(::ChiSqDist, ai, bi) = ifelse(ai != bi, abs2(ai - bi) / (ai + bi), zero(abs2(ai - bi) / (ai + bi)))
+@inline eval_op(::ChiSqDist, ai, bi) = (d = abs2(ai - bi) / (ai + bi); ifelse(ai != bi, d, zero(d)))
 @inline eval_reduce(::ChiSqDist, s1, s2) = s1 + s2
 chisq_dist(a::AbstractArray, b::AbstractArray) = evaluate(ChiSqDist(), a, b)
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -161,6 +161,8 @@ end
             @test wminkowski(x, y, w, 2) ≈ weuclidean(x, y, w)
         end
 
+        # Test ChiSq doesn't give NaN at zero
+        @test chisq_dist([0.0], [0.0]) == 0.0
 
         # Test weighted Hamming distances with even weights
         a = T.([1.0, 2.0, 1.0, 3.0, 2.0, 1.0])


### PR DESCRIPTION
Currently `chisq_dist([0.], [0.])` would generate `NaN`, but we can [continuously] define it (0, 0) to be 0.