### PR TITLE
Fix call to Haversine ctor in benchmark scripts

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -19,7 +19,7 @@ function create_distances(w, Q)
         BhattacharyyaDist(),
         HellingerDist(),
 
-        Haversine(),
+        Haversine(6371.),
 
         WeightedSqEuclidean(w),
         WeightedEuclidean(w),


### PR DESCRIPTION
We updated the interface for `Haversine` and forgot to update the benchmarks accordingly. This PR fixes the issue.