### PR TITLE
use unsafe_views and remove branch for arrays

### DIFF
--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -88,6 +88,7 @@ export
     rmsd,
     nrmsd
 
+include("unsafe_views.jl")
 include("common.jl")
 include("generic.jl")
 include("metrics.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -103,7 +103,7 @@ function sumsq_percol(a::AbstractMatrix{T}) where {T}
     n = size(a, 2)
     r = Vector{T}(n)
     for j = 1:n
-        aj = view(a, :, j)
+        aj = fastview(a, :, j)
         r[j] = dot(aj, aj)
     end
     return r
@@ -115,7 +115,7 @@ function wsumsq_percol(w::AbstractArray{T1}, a::AbstractMatrix{T2}) where {T1, T
     T = typeof(one(T1) * one(T2))
     r = Vector{T}(n)
     for j = 1:n
-        aj = view(a, :, j)
+        aj = fastview(a, :, j)
         s = zero(T)
         @simd for i = 1:m
             @inbounds s += w[i] * abs2(aj[i])
@@ -131,8 +131,8 @@ function dot_percol!(r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
     size(b) == (m, n) && length(r) == n ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     for j = 1:n
-        aj = view(a, :, j)
-        bj = view(b, :, j)
+        aj = fastview(a, :, j)
+        bj = fastview(b, :, j)
         r[j] = dot(aj, bj)
     end
     return r

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -33,7 +33,7 @@ function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractVector, b::Abs
     n = size(b, 2)
     length(r) == n || throw(DimensionMismatch("Incorrect size of r."))
     for j = 1:n
-        @inbounds r[j] = evaluate(metric, a, view(b, :, j))
+        @inbounds r[j] = evaluate(metric, a, fastview(b, :, j))
     end
     r
 end
@@ -42,7 +42,7 @@ function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractMatrix, b::Abs
     n = size(a, 2)
     length(r) == n || throw(DimensionMismatch("Incorrect size of r."))
     for j = 1:n
-        @inbounds r[j] = evaluate(metric, view(a, :, j), b)
+        @inbounds r[j] = evaluate(metric, fastview(a, :, j), b)
     end
     r
 end
@@ -51,7 +51,7 @@ function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractMatrix, b::Abs
     n = get_common_ncols(a, b)
     length(r) == n || throw(DimensionMismatch("Incorrect size of r."))
     for j = 1:n
-        @inbounds r[j] = evaluate(metric, view(a, :, j), view(b, :, j))
+        @inbounds r[j] = evaluate(metric, fastview(a, :, j), fastview(b, :, j))
     end
     r
 end
@@ -86,9 +86,9 @@ function pairwise!(r::AbstractMatrix, metric::PreMetric, a::AbstractMatrix, b::A
     nb = size(b, 2)
     size(r) == (na, nb) || throw(DimensionMismatch("Incorrect size of r."))
     for j = 1:size(b, 2)
-        bj = view(b, :, j)
+        bj = fastview(b, :, j)
         for i = 1:size(a, 2)
-            @inbounds r[i, j] = evaluate(metric, view(a, :, i), bj)
+            @inbounds r[i, j] = evaluate(metric, fastview(a, :, i), bj)
         end
     end
     r
@@ -102,9 +102,9 @@ function pairwise!(r::AbstractMatrix, metric::SemiMetric, a::AbstractMatrix)
     n = size(a, 2)
     size(r) == (n, n) || throw(DimensionMismatch("Incorrect size of r."))
     for j = 1:n
-        aj = view(a, :, j)
+        aj = fastview(a, :, j)
         for i = (j + 1):n
-            @inbounds r[i, j] = evaluate(metric, view(a, :, i), aj)
+            @inbounds r[i, j] = evaluate(metric, fastview(a, :, i), aj)
         end
         @inbounds r[j, j] = 0
         for i = 1:(j - 1)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -144,7 +144,24 @@ SqEuclidean() = SqEuclidean(0)
 #
 ###########################################################
 
-function evaluate(d::UnionMetrics, a::AbstractArray, b::AbstractArray)
+# Specialized for Arrays and avoids a branch on the size
+@inline function evaluate(d::UnionMetrics, a::T, b::T) where T <: Union{Array, UnsafeVectorView}
+    if length(a) != length(b)
+        throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
+    end
+    if length(a) == 0
+        return zero(result_type(d, a, b))
+    end
+    s = eval_start(d, a, b)
+    @simd for I in eachindex(a, b)
+        @inbounds ai = a[I]
+        @inbounds bi = b[I]
+        s = eval_reduce(d, s, eval_op(d, ai, bi))
+    end
+    return eval_end(d, s)
+end
+
+@inline function evaluate(d::UnionMetrics, a::AbstractArray, b::AbstractArray)
     if length(a) != length(b)
         throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
     end
@@ -235,6 +252,8 @@ cosine_dist(a::AbstractArray, b::AbstractArray) = evaluate(CosineDist(), a, b)
 # Correlation Dist
 _centralize(x::AbstractArray) = x .- mean(x)
 evaluate(::CorrDist, a::AbstractArray, b::AbstractArray) = cosine_dist(_centralize(a), _centralize(b))
+# Ambiguity resolution
+evaluate(::CorrDist, a::T, b::T) where {T <: Union{Array, UnsafeVectorView}} = cosine_dist(_centralize(a), _centralize(b))
 corr_dist(a::AbstractArray, b::AbstractArray) = evaluate(CorrDist(), a, b)
 result_type(::CorrDist, a::AbstractArray, b::AbstractArray) = result_type(CosineDist(), a, b)
 

--- a/src/unsafe_views.jl
+++ b/src/unsafe_views.jl
@@ -1,0 +1,40 @@
+# Copied from https://github.com/rdeits/NNLS.jl/blob/7017cbbedfb40a4dac52c448545d217f685e4150/src/NNLS.jl#L211
+# Copyright (c) 2017: Robin Deits.
+
+"""
+Views in Julia still allocate some memory (since they need to keep
+a reference to the original array). This type allocates no memory
+and does no bounds checking. Use it with caution.
+"""
+immutable UnsafeVectorView{T} <: AbstractVector{T}
+    offset::Int
+    len::Int
+    ptr::Ptr{T}
+end
+
+@inline UnsafeVectorView{T}(parent::DenseArray{T}, start_ind::Integer, len::Integer) = UnsafeVectorView{T}(start_ind - 1, len, pointer(parent))
+@inline Base.size(v::UnsafeVectorView) = (v.len,)
+@inline Base.getindex(v::UnsafeVectorView, idx) = unsafe_load(v.ptr, idx + v.offset)
+@inline Base.setindex!(v::UnsafeVectorView, value, idx) = unsafe_store!(v.ptr, value, idx + v.offset)
+@inline Base.length(v::UnsafeVectorView) = v.len
+@inline Base.IndexStyle{V <: UnsafeVectorView}(::Type{V}) = Base.IndexLinear()
+
+"""
+UnsafeVectorView only works for isbits types. For other types, we're already
+allocating lots of memory elsewhere, so creating a new View is fine.
+This function looks type-unstable, but the isbits(T) test can be evaluated
+by the compiler, so the result is actually type-stable.
+"""
+@inline function fastview{T}(parent::Matrix{T}, ::Colon, col::Int)
+    if isbits(T)
+        UnsafeVectorView(parent, size(parent, 1) * (col - 1) + 1, size(parent, 1))
+    else
+        @view(parent[start_ind:(start_ind + len - 1)])
+    end
+end
+
+"""
+Fallback for non-contiguous arrays, for which UnsafeVectorView does not make
+sense.
+"""
+fastview(parent::AbstractArray, start_ind::Integer, len::Integer) = @view(parent[start_ind:(start_ind + len - 1)])


### PR DESCRIPTION
An alternative for solving https://github.com/JuliaStats/Distances.jl/issues/83

```
julia> println("distances.jl colwise")
distances.jl colwise

julia> show(STDOUT, MIME"text/plain"(), bench_colw)
BenchmarkTools.Trial:
  memory estimate:  781.33 KiB
  allocs estimate:  2
  --------------
  minimum time:     1.082 ms (0.00% GC)
  median time:      1.256 ms (0.00% GC)
  mean time:        1.364 ms (2.21% GC)
  maximum time:     3.484 ms (24.77% GC)
  --------------
  samples:          3644
  evals/sample:     1
julia> println("\nnaive colwise")

naive colwise

julia> show(STDOUT, MIME"text/plain"(), bench_colw2)
BenchmarkTools.Trial:
  memory estimate:  781.33 KiB
  allocs estimate:  2
  --------------
  minimum time:     1.072 ms (0.00% GC)
  median time:      1.275 ms (0.00% GC)
  mean time:        1.354 ms (2.25% GC)
  maximum time:     3.658 ms (32.67% GC)
  --------------
  samples:          3670
  evals/sample:     1
```

cc @chethega

