### PR TITLE
make Minkowski distance a parametric type

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -17,9 +17,8 @@ struct Cityblock <: Metric end
 struct Jaccard <: Metric end
 struct RogersTanimoto <: Metric end
 
-struct Minkowski{T <: Real} <: Metric
-    p::T
-end
+struct Minkowski{p} <: Metric end
+Minkowski(p::T) where {T <: Real} = Minkowski{p}()
 
 struct Hamming <: Metric end
 
@@ -228,9 +227,9 @@ chebyshev(a::AbstractArray, b::AbstractArray) = evaluate(Chebyshev(), a, b)
 chebyshev(a::T, b::T) where {T <: Number} = evaluate(Chebyshev(), a, b)
 
 # Minkowski
-@inline eval_op(dist::Minkowski, ai, bi) = abs(ai - bi).^dist.p
+@inline eval_op(dist::Minkowski{p}, ai, bi) where {p} = abs(ai - bi).^p
 @inline eval_reduce(::Minkowski, s1, s2) = s1 + s2
-eval_end(dist::Minkowski, s) = s.^(1 / dist.p)
+eval_end(dist::Minkowski{p}, s) where {p} = s.^(1 / p)
 minkowski(a::AbstractArray, b::AbstractArray, p::Real) = evaluate(Minkowski(p), a, b)
 minkowski(a::T, b::T, p::Real) where {T <: Number} = evaluate(Minkowski(p), a, b)
 

--- a/src/wmetrics.jl
+++ b/src/wmetrics.jl
@@ -21,10 +21,11 @@ struct WeightedCityblock{W <: RealAbstractArray} <: Metric
     weights::W
 end
 
-struct WeightedMinkowski{W <: RealAbstractArray,T <: Real} <: Metric
+struct WeightedMinkowski{W <: RealAbstractArray,p} <: Metric
     weights::W
-    p::T
 end
+WeightedMinkowski(w::W, p::T) where {W <: RealAbstractArray, T <: Real} =
+    WeightedMinkowski{W, p}(w)
 
 struct WeightedHamming{W <: RealAbstractArray} <: Metric
     weights::W
@@ -100,9 +101,9 @@ weuclidean(a::AbstractArray, b::AbstractArray, w::AbstractArray) = evaluate(Weig
 wcityblock(a::AbstractArray, b::AbstractArray, w::AbstractArray) = evaluate(WeightedCityblock(w), a, b)
 
 # Minkowski
-@inline eval_op(dist::WeightedMinkowski, ai, bi, wi) = abs(ai - bi).^dist.p * wi
+@inline eval_op(dist::WeightedMinkowski{W,p}, ai, bi, wi) where {W,p} = abs(ai - bi).^p * wi
 @inline eval_reduce(::WeightedMinkowski, s1, s2) = s1 + s2
-eval_end(dist::WeightedMinkowski, s) = s.^(1 / dist.p)
+eval_end(dist::WeightedMinkowski{W,p}, s) where {W,p} = s.^(1 / p)
 wminkowski(a::AbstractArray, b::AbstractArray, w::AbstractArray, p::Real) = evaluate(WeightedMinkowski(w, p), a, b)
 
 # WeightedHamming


### PR DESCRIPTION
This fixes #56. Unfortunately, this (currently) does not yield any performance improvements except for `p=1` and `p=2` (which is nothing but `Euclidean()`). At least, it doesn't seem to make things worse. Comments welcome.