### PR TITLE
Get docstring without @doc to avoid error when compiling

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -332,10 +332,12 @@ function eval_end(dist::RenyiDivergence, s::Tuple{T,T,T,T}) where {T <: Real}
     end
 end
 
-# Combine docs with RenyiDivergence
-@doc (@doc RenyiDivergence) renyi_divergence
-
 renyi_divergence(a::AbstractArray, b::AbstractArray, q::Real) = evaluate(RenyiDivergence(q), a, b)
+# Combine docs with RenyiDivergence. Getting the docstring with @doc causes
+# problems with package compilation.
+let docstring = Base.Docs.getdoc(RenyiDivergence)
+    @doc docstring renyi_divergence
+end
 
 # JSDivergence
 @inline function eval_op(::JSDivergence, ai::T, bi::T) where {T}

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -333,8 +333,9 @@ function eval_end(dist::RenyiDivergence, s::Tuple{T,T,T,T}) where {T <: Real}
 end
 
 renyi_divergence(a::AbstractArray, b::AbstractArray, q::Real) = evaluate(RenyiDivergence(q), a, b)
-# Combine docs with RenyiDivergence. Getting the docstring with @doc causes
-# problems with package compilation.
+# Combine docs with RenyiDivergence. Fetching the docstring with @doc causes
+# problems during package compilation; see
+# https://github.com/JuliaLang/julia/issues/31640
 let docstring = Base.Docs.getdoc(RenyiDivergence)
     @doc docstring renyi_divergence
 end


### PR DESCRIPTION
Fixes #113.

I'm not exactly sure what the problem was, because the error was happening during compilation with PackageCompiler but not when simply loading the module.  In any case, using `@doc` for getting the docstring led to trying to look up docstring at parse time in a context where `RenyiDivergence` was undefined, and this change shifts the lookup to happen during evaluation of the module definition.