### PR TITLE
restrict eltype to Number

### DIFF
--- a/src/bregman.jl
+++ b/src/bregman.jl
@@ -22,7 +22,7 @@ end
 Bregman(F, ∇) =  Bregman(F, ∇, LinearAlgebra.dot)
 
 # Evaluation fuction 
-function evaluate(dist::Bregman, p::AbstractVector, q::AbstractVector)
+function evaluate(dist::Bregman, p::AbstractVector{<:Number}, q::AbstractVector{<:Number})
     # Create cache vals.
     FP_val = dist.F(p);
     FQ_val = dist.F(q); 

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,33 +6,33 @@
 #
 ###########################################################
 
-function get_common_ncols(a::AbstractMatrix, b::AbstractMatrix)
+function get_common_ncols(a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     na = size(a, 2)
     size(b, 2) == na || throw(DimensionMismatch("The number of columns in a and b must match."))
     return na
 end
 
-function get_colwise_dims(r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
+function get_colwise_dims(r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     size(a) == size(b) || throw(DimensionMismatch("The sizes of a and b must match."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_colwise_dims(r::AbstractArray, a::AbstractVector, b::AbstractMatrix)
+function get_colwise_dims(r::AbstractArray{<:Number}, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number})
     length(a) == size(b, 1) ||
         throw(DimensionMismatch("The length of a must match the number of rows in b."))
     length(r) == size(b, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(b)
 end
 
-function get_colwise_dims(r::AbstractArray, a::AbstractMatrix, b::AbstractVector)
+function get_colwise_dims(r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractVector{<:Number})
     size(a, 1) == length(b) ||
         throw(DimensionMismatch("The length of b must match the number of rows in a."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_pairwise_dims(r::AbstractMatrix, a::AbstractMatrix, b::AbstractMatrix)
+function get_pairwise_dims(r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     ma, na = size(a)
     mb, nb = size(b)
     ma == mb || throw(DimensionMismatch("The numbers of rows or columns in a and b must match."))
@@ -40,7 +40,7 @@ function get_pairwise_dims(r::AbstractMatrix, a::AbstractMatrix, b::AbstractMatr
     return (ma, na, nb)
 end
 
-function get_pairwise_dims(r::AbstractMatrix, a::AbstractMatrix)
+function get_pairwise_dims(r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number})
     m, n = size(a)
     size(r) == (n, n) || throw(DimensionMismatch("Incorrect size of r."))
     return (m, n)
@@ -49,28 +49,28 @@ end
 
 # for metrics with fixed dimension (e.g. weighted metrics)
 
-function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
+function get_colwise_dims(d::Int, r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     size(a, 1) == size(b, 1) == d ||
         throw(DimensionMismatch("Incorrect vector dimensions."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractVector, b::AbstractMatrix)
+function get_colwise_dims(d::Int, r::AbstractArray{<:Number}, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number})
     length(a) == size(b, 1) == d ||
         throw(DimensionMismatch("Incorrect vector dimensions."))
     length(r) == size(b, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(b)
 end
 
-function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractMatrix, b::AbstractVector)
+function get_colwise_dims(d::Int, r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractVector{<:Number})
     size(a, 1) == length(b) == d ||
         throw(DimensionMismatch("Incorrect vector dimensions."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_pairwise_dims(d::Int, r::AbstractMatrix, a::AbstractMatrix, b::AbstractMatrix)
+function get_pairwise_dims(d::Int, r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     na = size(a, 2)
     nb = size(b, 2)
     size(a, 1) == size(b, 1) == d || throw(DimensionMismatch("Incorrect vector dimensions."))
@@ -78,7 +78,7 @@ function get_pairwise_dims(d::Int, r::AbstractMatrix, a::AbstractMatrix, b::Abst
     return (d, na, nb)
 end
 
-function get_pairwise_dims(d::Int, r::AbstractMatrix, a::AbstractMatrix)
+function get_pairwise_dims(d::Int, r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number})
     n = size(a, 2)
     size(a, 1) == d || throw(DimensionMismatch("Incorrect vector dimensions."))
     size(r) == (n, n) || throw(DimensionMismatch("Incorrect size of r."))
@@ -91,14 +91,14 @@ end
 #
 ###########################################################
 
-function sqrt!(a::AbstractArray)
+function sqrt!(a::AbstractArray{<:Number})
     @simd for i in eachindex(a)
         @inbounds a[i] = sqrt(a[i])
     end
     a
 end
 
-function sumsq_percol(a::AbstractMatrix{T}) where {T}
+function sumsq_percol(a::AbstractMatrix{T}) where {T<:Number}
     m = size(a, 1)
     n = size(a, 2)
     r = Vector{T}(undef, n)
@@ -109,7 +109,7 @@ function sumsq_percol(a::AbstractMatrix{T}) where {T}
     return r
 end
 
-function wsumsq_percol(w::AbstractArray{T1}, a::AbstractMatrix{T2}) where {T1, T2}
+function wsumsq_percol(w::AbstractArray{T1}, a::AbstractMatrix{T2}) where {T1<:Number, T2<:Number}
     m = size(a, 1)
     n = size(a, 2)
     T = typeof(one(T1) * one(T2))
@@ -125,7 +125,7 @@ function wsumsq_percol(w::AbstractArray{T1}, a::AbstractMatrix{T2}) where {T1, T
     return r
 end
 
-function dot_percol!(r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
+function dot_percol!(r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     m = size(a, 1)
     n = size(a, 2)
     size(b) == (m, n) && length(r) == n ||
@@ -138,4 +138,7 @@ function dot_percol!(r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
     return r
 end
 
-dot_percol(a::AbstractMatrix, b::AbstractMatrix) = dot_percol!(Vector{Float64}(undef, size(a, 2)), a, b)
+function dot_percol(a::AbstractMatrix{T1}, b::AbstractMatrix{T2}) where {T1<:Number, T2<:Number}
+    T = promote_type(T1, T2) 
+    dot_percol!(Vector{T}(undef, size(a, 2)), a, b)
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,33 +6,33 @@
 #
 ###########################################################
 
-function get_common_ncols(a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
+function get_common_ncols(a::AbstractMatrix, b::AbstractMatrix)
     na = size(a, 2)
     size(b, 2) == na || throw(DimensionMismatch("The number of columns in a and b must match."))
     return na
 end
 
-function get_colwise_dims(r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
+function get_colwise_dims(r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
     size(a) == size(b) || throw(DimensionMismatch("The sizes of a and b must match."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_colwise_dims(r::AbstractArray{<:Number}, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number})
+function get_colwise_dims(r::AbstractArray, a::AbstractVector, b::AbstractMatrix)
     length(a) == size(b, 1) ||
         throw(DimensionMismatch("The length of a must match the number of rows in b."))
     length(r) == size(b, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(b)
 end
 
-function get_colwise_dims(r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractVector{<:Number})
+function get_colwise_dims(r::AbstractArray, a::AbstractMatrix, b::AbstractVector)
     size(a, 1) == length(b) ||
         throw(DimensionMismatch("The length of b must match the number of rows in a."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_pairwise_dims(r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
+function get_pairwise_dims(r::AbstractMatrix, a::AbstractMatrix, b::AbstractMatrix)
     ma, na = size(a)
     mb, nb = size(b)
     ma == mb || throw(DimensionMismatch("The numbers of rows or columns in a and b must match."))
@@ -40,7 +40,7 @@ function get_pairwise_dims(r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Numb
     return (ma, na, nb)
 end
 
-function get_pairwise_dims(r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number})
+function get_pairwise_dims(r::AbstractMatrix, a::AbstractMatrix)
     m, n = size(a)
     size(r) == (n, n) || throw(DimensionMismatch("Incorrect size of r."))
     return (m, n)
@@ -49,28 +49,28 @@ end
 
 # for metrics with fixed dimension (e.g. weighted metrics)
 
-function get_colwise_dims(d::Int, r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
+function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractMatrix, b::AbstractMatrix)
     size(a, 1) == size(b, 1) == d ||
         throw(DimensionMismatch("Incorrect vector dimensions."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_colwise_dims(d::Int, r::AbstractArray{<:Number}, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number})
+function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractVector, b::AbstractMatrix)
     length(a) == size(b, 1) == d ||
         throw(DimensionMismatch("Incorrect vector dimensions."))
     length(r) == size(b, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(b)
 end
 
-function get_colwise_dims(d::Int, r::AbstractArray{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractVector{<:Number})
+function get_colwise_dims(d::Int, r::AbstractArray, a::AbstractMatrix, b::AbstractVector)
     size(a, 1) == length(b) == d ||
         throw(DimensionMismatch("Incorrect vector dimensions."))
     length(r) == size(a, 2) || throw(DimensionMismatch("Incorrect size of r."))
     return size(a)
 end
 
-function get_pairwise_dims(d::Int, r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
+function get_pairwise_dims(d::Int, r::AbstractMatrix, a::AbstractMatrix, b::AbstractMatrix)
     na = size(a, 2)
     nb = size(b, 2)
     size(a, 1) == size(b, 1) == d || throw(DimensionMismatch("Incorrect vector dimensions."))
@@ -78,7 +78,7 @@ function get_pairwise_dims(d::Int, r::AbstractMatrix{<:Number}, a::AbstractMatri
     return (d, na, nb)
 end
 
-function get_pairwise_dims(d::Int, r::AbstractMatrix{<:Number}, a::AbstractMatrix{<:Number})
+function get_pairwise_dims(d::Int, r::AbstractMatrix, a::AbstractMatrix)
     n = size(a, 2)
     size(a, 1) == d || throw(DimensionMismatch("Incorrect vector dimensions."))
     size(r) == (n, n) || throw(DimensionMismatch("Incorrect size of r."))

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -24,7 +24,7 @@ abstract type Metric <: SemiMetric end
 
 # Generic functions
 
-result_type(::PreMetric, ::AbstractArray{<:Number}, ::AbstractArray{<:Number}) = Float64
+result_type(::PreMetric, ::AbstractArray, ::AbstractArray) = Float64
 
 
 # Generic column-wise evaluation

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -24,12 +24,12 @@ abstract type Metric <: SemiMetric end
 
 # Generic functions
 
-result_type(::PreMetric, ::AbstractArray, ::AbstractArray) = Float64
+result_type(::PreMetric, ::AbstractArray{<:Number}, ::AbstractArray{<:Number}) = Float64
 
 
 # Generic column-wise evaluation
 
-function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractVector, b::AbstractMatrix)
+function colwise!(r::AbstractArray{<:Number}, metric::PreMetric, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number})
     n = size(b, 2)
     length(r) == n || throw(DimensionMismatch("Incorrect size of r."))
     @inbounds for j = 1:n
@@ -38,7 +38,7 @@ function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractVector, b::Abs
     r
 end
 
-function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractMatrix, b::AbstractVector)
+function colwise!(r::AbstractArray{<:Number}, metric::PreMetric, a::AbstractMatrix{<:Number}, b::AbstractVector{<:Number})
     n = size(a, 2)
     length(r) == n || throw(DimensionMismatch("Incorrect size of r."))
     @inbounds for j = 1:n
@@ -47,7 +47,7 @@ function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractMatrix, b::Abs
     r
 end
 
-function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix)
+function colwise!(r::AbstractArray{<:Number}, metric::PreMetric, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     n = get_common_ncols(a, b)
     length(r) == n || throw(DimensionMismatch("Incorrect size of r."))
     @inbounds for j = 1:n
@@ -56,23 +56,23 @@ function colwise!(r::AbstractArray, metric::PreMetric, a::AbstractMatrix, b::Abs
     r
 end
 
-function colwise!(r::AbstractArray, metric::SemiMetric, a::AbstractMatrix, b::AbstractVector)
+function colwise!(r::AbstractArray{<:Number}, metric::SemiMetric, a::AbstractMatrix{<:Number}, b::AbstractVector{<:Number})
     colwise!(r, metric, b, a)
 end
 
-function colwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix)
+function colwise(metric::PreMetric, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     n = get_common_ncols(a, b)
     r = Vector{result_type(metric, a, b)}(undef, n)
     colwise!(r, metric, a, b)
 end
 
-function colwise(metric::PreMetric, a::AbstractVector, b::AbstractMatrix)
+function colwise(metric::PreMetric, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number})
     n = size(b, 2)
     r = Vector{result_type(metric, a, b)}(undef, n)
     colwise!(r, metric, a, b)
 end
 
-function colwise(metric::PreMetric, a::AbstractMatrix, b::AbstractVector)
+function colwise(metric::PreMetric, a::AbstractMatrix{<:Number}, b::AbstractVector{<:Number})
     n = size(a, 2)
     r = Vector{result_type(metric, a, b)}(undef, n)
     colwise!(r, metric, a, b)
@@ -81,8 +81,8 @@ end
 
 # Generic pairwise evaluation
 
-function _pairwise!(r::AbstractMatrix, metric::PreMetric,
-                    a::AbstractMatrix, b::AbstractMatrix=a)
+function _pairwise!(r::AbstractMatrix{<:Number}, metric::PreMetric,
+                    a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number}=a)
     na = size(a, 2)
     nb = size(b, 2)
     size(r) == (na, nb) || throw(DimensionMismatch("Incorrect size of r."))
@@ -95,7 +95,7 @@ function _pairwise!(r::AbstractMatrix, metric::PreMetric,
     r
 end
 
-function _pairwise!(r::AbstractMatrix, metric::SemiMetric, a::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, metric::SemiMetric, a::AbstractMatrix{<:Number})
     n = size(a, 2)
     size(r) == (n, n) || throw(DimensionMismatch("Incorrect size of r."))
     @inbounds for j = 1:n
@@ -133,8 +133,8 @@ If a single matrix `a` is provided, compute distances between its rows or column
 `a` and `b` must have the same numbers of columns if `dims=1`, or of rows if `dims=2`.
 `r` must be a square matrix with size `size(a, dims) == size(b, dims)`.
 """
-function pairwise!(r::AbstractMatrix, metric::PreMetric,
-                   a::AbstractMatrix, b::AbstractMatrix;
+function pairwise!(r::AbstractMatrix{<:Number}, metric::PreMetric,
+                   a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number};
                    dims::Union{Nothing,Integer}=nothing)
     dims = deprecated_dims(dims)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
@@ -158,7 +158,7 @@ function pairwise!(r::AbstractMatrix, metric::PreMetric,
     end
 end
 
-function pairwise!(r::AbstractMatrix, metric::PreMetric, a::AbstractMatrix;
+function pairwise!(r::AbstractMatrix{<:Number}, metric::PreMetric, a::AbstractMatrix{<:Number};
                    dims::Union{Nothing,Integer}=nothing)
     dims = deprecated_dims(dims)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
@@ -185,7 +185,7 @@ compute distances between its rows or columns.
 
 `a` and `b` must have the same numbers of columns if `dims=1`, or of rows if `dims=2`.
 """
-function pairwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix;
+function pairwise(metric::PreMetric, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number};
                   dims::Union{Nothing,Integer}=nothing)
     dims = deprecated_dims(dims)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
@@ -195,7 +195,7 @@ function pairwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix;
     pairwise!(r, metric, a, b, dims=dims)
 end
 
-function pairwise(metric::PreMetric, a::AbstractMatrix;
+function pairwise(metric::PreMetric, a::AbstractMatrix{<:Number};
                   dims::Union{Nothing,Integer}=nothing)
     dims = deprecated_dims(dims)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -10,7 +10,7 @@ struct Haversine{T<:Real} <: Metric
     radius::T
 end
 
-const VecOrLengthTwoTuple{T} = Union{AbstractVector{T}, NTuple{2, T}}
+const VecOrLengthTwoTuple{T<:Number} = Union{AbstractVector{T}, NTuple{2, T}}
 
 function evaluate(dist::Haversine, x::VecOrLengthTwoTuple, y::VecOrLengthTwoTuple)
     length(x) == length(y) == 2 || haversine_error()

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -8,12 +8,12 @@ struct SqMahalanobis{T} <: SemiMetric
     qmat::Matrix{T}
 end
 
-result_type(::Mahalanobis{T}, ::AbstractArray, ::AbstractArray) where {T} = T
-result_type(::SqMahalanobis{T}, ::AbstractArray, ::AbstractArray) where {T} = T
+result_type(::Mahalanobis{T}, ::AbstractArray{<:Number}, ::AbstractArray{<:Number}) where {T} = T
+result_type(::SqMahalanobis{T}, ::AbstractArray{<:Number}, ::AbstractArray{<:Number}) where {T} = T
 
 # SqMahalanobis
 
-function evaluate(dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractVector) where {T <: Real}
+function evaluate(dist::SqMahalanobis{T}, a::AbstractVector{<:Number}, b::AbstractVector{<:Number}) where {T <: Real}
     if length(a) != length(b)
         throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
     end
@@ -23,16 +23,16 @@ function evaluate(dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractVector) 
     return dot(z, Q * z)
 end
 
-sqmahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = evaluate(SqMahalanobis(Q), a, b)
+sqmahalanobis(a::AbstractVector{<:Number}, b::AbstractVector{<:Number}, Q::AbstractMatrix{<:Number}) = evaluate(SqMahalanobis(Q), a, b)
 
-function colwise!(r::AbstractArray, dist::SqMahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix) where {T <: Real}
+function colwise!(r::AbstractArray{<:Number}, dist::SqMahalanobis{T}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number}) where {T <: Real}
     Q = dist.qmat
     m, n = get_colwise_dims(size(Q, 1), r, a, b)
     z = a - b
     dot_percol!(r, Q * z, z)
 end
 
-function colwise!(r::AbstractArray, dist::SqMahalanobis{T}, a::AbstractVector, b::AbstractMatrix) where {T <: Real}
+function colwise!(r::AbstractArray{<:Number}, dist::SqMahalanobis{T}, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number}) where {T <: Real}
     Q = dist.qmat
     m, n = get_colwise_dims(size(Q, 1), r, a, b)
     z = a .- b
@@ -40,8 +40,8 @@ function colwise!(r::AbstractArray, dist::SqMahalanobis{T}, a::AbstractVector, b
     dot_percol!(r, Q * z, z)
 end
 
-function _pairwise!(r::AbstractMatrix, dist::SqMahalanobis{T},
-                    a::AbstractMatrix, b::AbstractMatrix) where {T <: Real}
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::SqMahalanobis{T},
+                    a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number}) where {T <: Real}
     Q = dist.qmat
     m, na, nb = get_pairwise_dims(size(Q, 1), r, a, b)
 
@@ -59,8 +59,8 @@ function _pairwise!(r::AbstractMatrix, dist::SqMahalanobis{T},
     r
 end
 
-function _pairwise!(r::AbstractMatrix, dist::SqMahalanobis{T},
-                    a::AbstractMatrix) where {T <: Real}
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::SqMahalanobis{T},
+                    a::AbstractMatrix{<:Number}) where {T <: Real}
     Q = dist.qmat
     m, n = get_pairwise_dims(size(Q, 1), r, a)
 
@@ -83,26 +83,26 @@ end
 
 # Mahalanobis
 
-function evaluate(dist::Mahalanobis{T}, a::AbstractVector, b::AbstractVector) where {T <: Real}
+function evaluate(dist::Mahalanobis{T}, a::AbstractVector{<:Number}, b::AbstractVector{<:Number}) where {T <: Real}
     sqrt(evaluate(SqMahalanobis(dist.qmat), a, b))
 end
 
-mahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = evaluate(Mahalanobis(Q), a, b)
+mahalanobis(a::AbstractVector{<:Number}, b::AbstractVector{<:Number}, Q::AbstractMatrix{<:Number}) = evaluate(Mahalanobis(Q), a, b)
 
-function colwise!(r::AbstractArray, dist::Mahalanobis{T}, a::AbstractMatrix, b::AbstractMatrix) where {T <: Real}
+function colwise!(r::AbstractArray{<:Number}, dist::Mahalanobis{T}, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number}) where {T <: Real}
     sqrt!(colwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
-function colwise!(r::AbstractArray, dist::Mahalanobis{T}, a::AbstractVector, b::AbstractMatrix) where {T <: Real}
+function colwise!(r::AbstractArray{<:Number}, dist::Mahalanobis{T}, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number}) where {T <: Real}
     sqrt!(colwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
-function _pairwise!(r::AbstractMatrix, dist::Mahalanobis{T},
-                    a::AbstractMatrix, b::AbstractMatrix) where {T <: Real}
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::Mahalanobis{T},
+                    a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number}) where {T <: Real}
     sqrt!(_pairwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
-function _pairwise!(r::AbstractMatrix, dist::Mahalanobis{T},
-                    a::AbstractMatrix) where {T <: Real}
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::Mahalanobis{T},
+                    a::AbstractMatrix{<:Number}) where {T <: Real}
     sqrt!(_pairwise!(r, SqMahalanobis(dist.qmat), a))
 end

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -8,8 +8,8 @@ struct SqMahalanobis{T} <: SemiMetric
     qmat::Matrix{T}
 end
 
-result_type(::Mahalanobis{T}, ::AbstractArray{<:Number}, ::AbstractArray{<:Number}) where {T} = T
-result_type(::SqMahalanobis{T}, ::AbstractArray{<:Number}, ::AbstractArray{<:Number}) where {T} = T
+result_type(::Mahalanobis{T}, ::AbstractArray, ::AbstractArray) where {T} = T
+result_type(::SqMahalanobis{T}, ::AbstractArray, ::AbstractArray) where {T} = T
 
 # SqMahalanobis
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -146,10 +146,10 @@ SqEuclidean() = SqEuclidean(0)
 #
 ###########################################################
 
-const ArraySlice{T} = SubArray{T,1,Array{T,2},Tuple{Base.Slice{Base.OneTo{Int}},Int},true}
+const ArraySlice{T<:Number} = SubArray{T,1,Array{T,2},Tuple{Base.Slice{Base.OneTo{Int}},Int},true}
 
 # Specialized for Arrays and avoids a branch on the size
-@inline Base.@propagate_inbounds function evaluate(d::UnionMetrics, a::Union{Array, ArraySlice}, b::Union{Array, ArraySlice})
+@inline Base.@propagate_inbounds function evaluate(d::UnionMetrics, a::Union{Array{<:Number}, ArraySlice}, b::Union{Array{<:Number}, ArraySlice})
     @boundscheck if length(a) != length(b)
         throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
     end
@@ -167,7 +167,7 @@ const ArraySlice{T} = SubArray{T,1,Array{T,2},Tuple{Base.Slice{Base.OneTo{Int}},
     end
 end
 
-@inline function evaluate(d::UnionMetrics, a::AbstractArray, b::AbstractArray)
+@inline function evaluate(d::UnionMetrics, a::AbstractArray{<:Number}, b::AbstractArray{<:Number})
     @boundscheck if length(a) != length(b)
         throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
     end
@@ -192,7 +192,7 @@ end
     end
     return eval_end(d, s)
 end
-result_type(dist::UnionMetrics, ::AbstractArray{T1}, ::AbstractArray{T2}) where {T1, T2} =
+result_type(dist::UnionMetrics, ::AbstractArray{T1}, ::AbstractArray{T2}) where {T1<:Number, T2<:Number} =
     typeof(eval_end(dist, eval_op(dist, one(T1), one(T2))))
 eval_start(d::UnionMetrics, a::AbstractArray, b::AbstractArray) =
     zero(result_type(d, a, b))
@@ -204,48 +204,48 @@ evaluate(dist::UnionMetrics, a::T, b::T) where {T <: Number} = eval_end(dist, ev
 @inline eval_op(::SqEuclidean, ai, bi) = abs2(ai - bi)
 @inline eval_reduce(::SqEuclidean, s1, s2) = s1 + s2
 
-sqeuclidean(a::AbstractArray, b::AbstractArray) = evaluate(SqEuclidean(), a, b)
+sqeuclidean(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(SqEuclidean(), a, b)
 sqeuclidean(a::T, b::T) where {T <: Number} = evaluate(SqEuclidean(), a, b)
 
 # Euclidean
 @inline eval_op(::Euclidean, ai, bi) = abs2(ai - bi)
 @inline eval_reduce(::Euclidean, s1, s2) = s1 + s2
 eval_end(::Euclidean, s) = sqrt(s)
-euclidean(a::AbstractArray, b::AbstractArray) = evaluate(Euclidean(), a, b)
+euclidean(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(Euclidean(), a, b)
 euclidean(a::Number, b::Number) = evaluate(Euclidean(), a, b)
 
 # Cityblock
 @inline eval_op(::Cityblock, ai, bi) = abs(ai - bi)
 @inline eval_reduce(::Cityblock, s1, s2) = s1 + s2
-cityblock(a::AbstractArray, b::AbstractArray) = evaluate(Cityblock(), a, b)
+cityblock(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(Cityblock(), a, b)
 cityblock(a::T, b::T) where {T <: Number} = evaluate(Cityblock(), a, b)
 
 # Total variation
 @inline eval_op(::TotalVariation, ai, bi) = abs(ai - bi)
 @inline eval_reduce(::TotalVariation, s1, s2) = s1 + s2
 eval_end(::TotalVariation, s) = s / 2
-totalvariation(a::AbstractArray, b::AbstractArray) = evaluate(TotalVariation(), a, b)
+totalvariation(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(TotalVariation(), a, b)
 totalvariation(a::T, b::T) where {T <: Number} = evaluate(TotalVariation(), a, b)
 
 # Chebyshev
 @inline eval_op(::Chebyshev, ai, bi) = abs(ai - bi)
 @inline eval_reduce(::Chebyshev, s1, s2) = max(s1, s2)
 # if only NaN, will output NaN
-@inline Base.@propagate_inbounds eval_start(::Chebyshev, a::AbstractArray, b::AbstractArray) = abs(a[1] - b[1])
-chebyshev(a::AbstractArray, b::AbstractArray) = evaluate(Chebyshev(), a, b)
+@inline Base.@propagate_inbounds eval_start(::Chebyshev, a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = abs(a[1] - b[1])
+chebyshev(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(Chebyshev(), a, b)
 chebyshev(a::T, b::T) where {T <: Number} = evaluate(Chebyshev(), a, b)
 
 # Minkowski
 @inline eval_op(dist::Minkowski, ai, bi) = abs(ai - bi).^dist.p
 @inline eval_reduce(::Minkowski, s1, s2) = s1 + s2
 eval_end(dist::Minkowski, s) = s.^(1 / dist.p)
-minkowski(a::AbstractArray, b::AbstractArray, p::Real) = evaluate(Minkowski(p), a, b)
+minkowski(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}, p::Real) = evaluate(Minkowski(p), a, b)
 minkowski(a::T, b::T, p::Real) where {T <: Number} = evaluate(Minkowski(p), a, b)
 
 # Hamming
 @inline eval_op(::Hamming, ai, bi) = ai != bi ? 1 : 0
 @inline eval_reduce(::Hamming, s1, s2) = s1 + s2
-hamming(a::AbstractArray, b::AbstractArray) = evaluate(Hamming(), a, b)
+hamming(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(Hamming(), a, b)
 hamming(a::T, b::T) where {T <: Number} = evaluate(Hamming(), a, b)
 
 # Cosine dist
@@ -262,30 +262,30 @@ function eval_end(::CosineDist, s)
     ab, a2, b2 = s
     max(1 - ab / (sqrt(a2) * sqrt(b2)), zero(eltype(ab)))
 end
-cosine_dist(a::AbstractArray, b::AbstractArray) = evaluate(CosineDist(), a, b)
+cosine_dist(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(CosineDist(), a, b)
 
 # Correlation Dist
-_centralize(x::AbstractArray) = x .- mean(x)
-evaluate(::CorrDist, a::AbstractArray, b::AbstractArray) = cosine_dist(_centralize(a), _centralize(b))
+_centralize(x::AbstractArray{<:Number}) = x .- mean(x)
+evaluate(::CorrDist, a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = cosine_dist(_centralize(a), _centralize(b))
 # Ambiguity resolution
-evaluate(::CorrDist, a::Array, b::Array) = cosine_dist(_centralize(a), _centralize(b))
-corr_dist(a::AbstractArray, b::AbstractArray) = evaluate(CorrDist(), a, b)
-result_type(::CorrDist, a::AbstractArray, b::AbstractArray) = result_type(CosineDist(), a, b)
+evaluate(::CorrDist, a::Array{<:Number}, b::Array{<:Number}) = cosine_dist(_centralize(a), _centralize(b)) # CHECK if this is necessary
+corr_dist(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(CorrDist(), a, b)
+result_type(::CorrDist, a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = result_type(CosineDist(), a, b)
 
 # ChiSqDist
 @inline eval_op(::ChiSqDist, ai, bi) = (d = abs2(ai - bi) / (ai + bi); ifelse(ai != bi, d, zero(d)))
 @inline eval_reduce(::ChiSqDist, s1, s2) = s1 + s2
-chisq_dist(a::AbstractArray, b::AbstractArray) = evaluate(ChiSqDist(), a, b)
+chisq_dist(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(ChiSqDist(), a, b)
 
 # KLDivergence
 @inline eval_op(::KLDivergence, ai, bi) = ai > 0 ? ai * log(ai / bi) : zero(ai)
 @inline eval_reduce(::KLDivergence, s1, s2) = s1 + s2
-kl_divergence(a::AbstractArray, b::AbstractArray) = evaluate(KLDivergence(), a, b)
+kl_divergence(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(KLDivergence(), a, b)
 
 # GenKLDivergence
 @inline eval_op(::GenKLDivergence, ai, bi) = ai > 0 ? ai * log(ai / bi) - ai + bi : bi
 @inline eval_reduce(::GenKLDivergence, s1, s2) = s1 + s2
-gkl_divergence(a::AbstractArray, b::AbstractArray) = evaluate(GenKLDivergence(), a, b)
+gkl_divergence(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(GenKLDivergence(), a, b)
 
 # RenyiDivergence
 @inline Base.@propagate_inbounds function eval_start(::RenyiDivergence, a::AbstractArray{T}, b::AbstractArray{T}) where {T <: Real}
@@ -332,7 +332,7 @@ function eval_end(dist::RenyiDivergence, s::Tuple{T,T,T,T}) where {T <: Real}
     end
 end
 
-renyi_divergence(a::AbstractArray, b::AbstractArray, q::Real) = evaluate(RenyiDivergence(q), a, b)
+renyi_divergence(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}, q::Real) = evaluate(RenyiDivergence(q), a, b)
 # Combine docs with RenyiDivergence. Fetching the docstring with @doc causes
 # problems during package compilation; see
 # https://github.com/JuliaLang/julia/issues/31640
@@ -349,10 +349,10 @@ end
     ta + tb - tu
 end
 @inline eval_reduce(::JSDivergence, s1, s2) = s1 + s2
-js_divergence(a::AbstractArray, b::AbstractArray) = evaluate(JSDivergence(), a, b)
+js_divergence(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(JSDivergence(), a, b)
 
 # SpanNormDist
-@inline Base.@propagate_inbounds function eval_start(::SpanNormDist, a::AbstractArray, b::AbstractArray)
+@inline Base.@propagate_inbounds function eval_start(::SpanNormDist, a::AbstractArray{<:Number}, b::AbstractArray{<:Number})
     a[1] - b[1], a[1] - b[1]
 end
 @inline eval_op(::SpanNormDist, ai, bi)  = ai - bi
@@ -367,8 +367,8 @@ end
 end
 
 eval_end(::SpanNormDist, s) = s[2] - s[1]
-spannorm_dist(a::AbstractArray, b::AbstractArray) = evaluate(SpanNormDist(), a, b)
-function result_type(dist::SpanNormDist, ::AbstractArray{T1}, ::AbstractArray{T2}) where {T1, T2}
+spannorm_dist(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(SpanNormDist(), a, b)
+function result_type(dist::SpanNormDist, ::AbstractArray{T1}, ::AbstractArray{T2}) where {T1<:Number, T2<:Number}
     typeof(eval_op(dist, one(T1), one(T2)))
 end
 
@@ -376,7 +376,7 @@ end
 # Jaccard
 
 @inline eval_start(::Jaccard, a::AbstractArray{Bool}, b::AbstractArray{Bool}) = 0, 0
-@inline eval_start(::Jaccard, a::AbstractArray{T}, b::AbstractArray{T}) where {T} = zero(T), zero(T)
+@inline eval_start(::Jaccard, a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = zero(T), zero(T)
 @inline function eval_op(::Jaccard, s1, s2)
     abs_m = abs(s1 - s2)
     abs_p = abs(s1 + s2)
@@ -391,12 +391,12 @@ end
     @inbounds v = 1 - (a[1] / a[2])
     return v
 end
-jaccard(a::AbstractArray, b::AbstractArray) = evaluate(Jaccard(), a, b)
+jaccard(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(Jaccard(), a, b)
 
 # BrayCurtis
 
 @inline eval_start(::BrayCurtis, a::AbstractArray{Bool}, b::AbstractArray{Bool}) = 0, 0
-@inline eval_start(::BrayCurtis, a::AbstractArray{T}, b::AbstractArray{T}) where {T} = zero(T), zero(T)
+@inline eval_start(::BrayCurtis, a::AbstractArray{T}, b::AbstractArray{T}) where {T<:Number} = zero(T), zero(T)
 @inline function eval_op(::BrayCurtis, s1, s2)
     abs_m = abs(s1 - s2)
     abs_p = abs(s1 + s2)
@@ -411,12 +411,12 @@ end
     @inbounds v = a[1] / a[2]
     return v
 end
-braycurtis(a::AbstractArray, b::AbstractArray) = evaluate(BrayCurtis(), a, b)
+braycurtis(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(BrayCurtis(), a, b)
 
 
 # Tanimoto
 
-@inline eval_start(::RogersTanimoto, a::AbstractArray, b::AbstractArray) = 0, 0, 0, 0
+@inline eval_start(::RogersTanimoto, a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = 0, 0, 0, 0
 @inline function eval_op(::RogersTanimoto, s1, s2)
     tt = s1 && s2
     tf = s1 && !s2
@@ -465,8 +465,8 @@ nrmsd(a, b) = evaluate(NormRMSDeviation(), a, b)
 ###########################################################
 
 # SqEuclidean
-function _pairwise!(r::AbstractMatrix, dist::SqEuclidean,
-                    a::AbstractMatrix, b::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::SqEuclidean,
+                    a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     mul!(r, a', b)
     sa2 = sum(abs2, a, dims=1)
     sb2 = sum(abs2, b, dims=1)
@@ -502,7 +502,7 @@ function _pairwise!(r::AbstractMatrix, dist::SqEuclidean,
     r
 end
 
-function _pairwise!(r::AbstractMatrix, dist::SqEuclidean, a::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::SqEuclidean, a::AbstractMatrix{<:Number})
     m, n = get_pairwise_dims(r, a)
     mul!(r, a', a)
     sa2 = sumsq_percol(a)
@@ -535,8 +535,8 @@ function _pairwise!(r::AbstractMatrix, dist::SqEuclidean, a::AbstractMatrix)
 end
 
 # Euclidean
-function _pairwise!(r::AbstractMatrix, dist::Euclidean,
-                    a::AbstractMatrix, b::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::Euclidean,
+                    a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     m, na, nb = get_pairwise_dims(r, a, b)
     mul!(r, a', b)
     sa2 = sumsq_percol(a)
@@ -563,7 +563,7 @@ function _pairwise!(r::AbstractMatrix, dist::Euclidean,
     r
 end
 
-function _pairwise!(r::AbstractMatrix, dist::Euclidean, a::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::Euclidean, a::AbstractMatrix{<:Number})
     m, n = get_pairwise_dims(r, a)
     mul!(r, a', a)
     sa2 = sumsq_percol(a)
@@ -591,8 +591,8 @@ end
 
 # CosineDist
 
-function _pairwise!(r::AbstractMatrix, dist::CosineDist,
-                    a::AbstractMatrix, b::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::CosineDist,
+                    a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     m, na, nb = get_pairwise_dims(r, a, b)
     mul!(r, a', b)
     ra = sqrt!(sumsq_percol(a))
@@ -604,7 +604,7 @@ function _pairwise!(r::AbstractMatrix, dist::CosineDist,
     end
     r
 end
-function _pairwise!(r::AbstractMatrix, dist::CosineDist, a::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::CosineDist, a::AbstractMatrix{<:Number})
     m, n = get_pairwise_dims(r, a)
     mul!(r, a', a)
     ra = sqrt!(sumsq_percol(a))
@@ -621,18 +621,18 @@ function _pairwise!(r::AbstractMatrix, dist::CosineDist, a::AbstractMatrix)
 end
 
 # CorrDist
-_centralize_colwise(x::AbstractVector) = x .- mean(x)
-_centralize_colwise(x::AbstractMatrix) = x .- mean(x, dims=1)
-function colwise!(r::AbstractVector, dist::CorrDist, a::AbstractMatrix, b::AbstractMatrix)
+_centralize_colwise(x::AbstractVector{<:Number}) = x .- mean(x)
+_centralize_colwise(x::AbstractMatrix{<:Number}) = x .- mean(x, dims=1)
+function colwise!(r::AbstractVector{<:Number}, dist::CorrDist, a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     colwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
 end
-function colwise!(r::AbstractVector, dist::CorrDist, a::AbstractVector, b::AbstractMatrix)
+function colwise!(r::AbstractVector{<:Number}, dist::CorrDist, a::AbstractVector{<:Number}, b::AbstractMatrix{<:Number})
     colwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
 end
-function _pairwise!(r::AbstractMatrix, dist::CorrDist,
-                    a::AbstractMatrix, b::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::CorrDist,
+                    a::AbstractMatrix{<:Number}, b::AbstractMatrix{<:Number})
     _pairwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
 end
-function _pairwise!(r::AbstractMatrix, dist::CorrDist, a::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix{<:Number}, dist::CorrDist, a::AbstractMatrix{<:Number})
     _pairwise!(r, CosineDist(), _centralize_colwise(a))
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -442,20 +442,20 @@ rogerstanimoto(a::AbstractArray{T}, b::AbstractArray{T}) where {T <: Bool} = eva
 
 # Deviations
 
-evaluate(::MeanAbsDeviation, a, b) = cityblock(a, b) / length(a)
-meanad(a, b) = evaluate(MeanAbsDeviation(), a, b)
+evaluate(::MeanAbsDeviation, a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = cityblock(a, b) / length(a)
+meanad(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(MeanAbsDeviation(), a, b)
 
-evaluate(::MeanSqDeviation, a, b) = sqeuclidean(a, b) / length(a)
-msd(a, b) = evaluate(MeanSqDeviation(), a, b)
+evaluate(::MeanSqDeviation, a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = sqeuclidean(a, b) / length(a)
+msd(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(MeanSqDeviation(), a, b)
 
-evaluate(::RMSDeviation, a, b) = sqrt(evaluate(MeanSqDeviation(), a, b))
-rmsd(a, b) = evaluate(RMSDeviation(), a, b)
+evaluate(::RMSDeviation, a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = sqrt(evaluate(MeanSqDeviation(), a, b))
+rmsd(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(RMSDeviation(), a, b)
 
-function evaluate(::NormRMSDeviation, a, b)
+function evaluate(::NormRMSDeviation, a::AbstractArray{<:Number}, b::AbstractArray{<:Number})
     amin, amax = extrema(a)
     return evaluate(RMSDeviation(), a, b) / (amax - amin)
 end
-nrmsd(a, b) = evaluate(NormRMSDeviation(), a, b)
+nrmsd(a::AbstractArray{<:Number}, b::AbstractArray{<:Number}) = evaluate(NormRMSDeviation(), a, b)
 
 
 ###########################################################


### PR DESCRIPTION
There're some cases we calculate distances between `a::AbstractArray{T}, b::AbstractArray{T}` where `T` is not a number. For example, in image-processing `where {T<:AbstractArray}`.

By change from `AbstractArray{T}` to `AbstractArray{<:Number}`, this PR provides the ability for downstream packages(e.g., `ImageDistances`) to reuse codes in `Distances` with a simple dispatch strategy

The test says ok, but IF there's some `Premetric` that is not limited to `AbstractArray{<:Number}` type, please point it out.