### PR TITLE
correct NormRMSDeviation type

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -97,7 +97,7 @@ struct SpanNormDist <: SemiMetric end
 struct MeanAbsDeviation <: Metric end
 struct MeanSqDeviation <: SemiMetric end
 struct RMSDeviation <: Metric end
-struct NormRMSDeviation <: Metric end
+struct NormRMSDeviation <: PreMetric end
 
 
 const UnionMetrics = Union{Euclidean,SqEuclidean,Chebyshev,Cityblock,TotalVariation,Minkowski,Hamming,Jaccard,RogersTanimoto,CosineDist,CorrDist,ChiSqDist,KLDivergence,RenyiDivergence,BrayCurtis,JSDivergence,SpanNormDist,GenKLDivergence}


### PR DESCRIPTION
`rmsd(x, y) / (maximum(x) - minimum(x))` can't swap(`nrmsd(x,y)!=nrmsd(y,x)`), so it isn't a `SemiMetric`, this would introduce problems calling `pairwise`