### PR TITLE
Loosen type annotations and fix https://github.com/JuliaStats/Distances.jl/issues/130

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -109,10 +109,10 @@ function sumsq_percol(a::AbstractMatrix{T}) where {T}
     return r
 end
 
-function wsumsq_percol(w::AbstractArray{T1}, a::AbstractMatrix{T2}) where {T1, T2}
+function wsumsq_percol(w::AbstractArray, a::AbstractMatrix)
     m = size(a, 1)
     n = size(a, 2)
-    T = typeof(one(T1) * one(T2))
+    T = Base.promote_op((x, y) -> x * abs2(y), eltype(w), eltype(a))
     r = Vector{T}(undef, n)
     for j = 1:n
         aj = view(a, :, j)

--- a/src/common.jl
+++ b/src/common.jl
@@ -112,7 +112,7 @@ end
 function wsumsq_percol(w::AbstractArray, a::AbstractMatrix)
     m = size(a, 1)
     n = size(a, 2)
-    T = Base.promote_op((x, y) -> x * abs2(y), eltype(w), eltype(a))
+    T = typeof(zero(eltype(w)) * abs2(zero(eltype(a))))
     r = Vector{T}(undef, n)
     for j = 1:n
         aj = view(a, :, j)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -252,22 +252,21 @@ end
     end
     return eval_end(d, s)
 end
-result_type(dist::UnionMetrics, ::AbstractArray{T1}, ::AbstractArray{T2}) where {T1, T2} =
-    typeof(eval_end(dist, parameters(dist) === nothing ?
-                        eval_op(dist, one(T1), one(T2)) :
-                        eval_op(dist, one(T1), one(T2), one(eltype(dist)))))
+result_type(dist::UnionMetrics, a::AbstractArray, b::AbstractArray) =
+    Base.promote_op(evaluate, typeof(dist), eltype(a), eltype(b))
+
 eval_start(d::UnionMetrics, a::AbstractArray, b::AbstractArray) =
     zero(result_type(d, a, b))
 eval_end(d::UnionMetrics, s) = s
 
-evaluate(dist::UnionMetrics, a::T, b::T) where {T <: Number} = eval_end(dist, eval_op(dist, a, b))
+evaluate(dist::UnionMetrics, a::Number, b::Number) = eval_end(dist, eval_op(dist, a, b))
 
 # SqEuclidean
 @inline eval_op(::SqEuclidean, ai, bi) = abs2(ai - bi)
 @inline eval_reduce(::SqEuclidean, s1, s2) = s1 + s2
 
 sqeuclidean(a::AbstractArray, b::AbstractArray) = evaluate(SqEuclidean(), a, b)
-sqeuclidean(a::T, b::T) where {T <: Number} = evaluate(SqEuclidean(), a, b)
+sqeuclidean(a::Number, b::Number) = evaluate(SqEuclidean(), a, b)
 
 # Euclidean
 @inline eval_op(::Euclidean, ai, bi) = abs2(ai - bi)
@@ -287,7 +286,7 @@ Base.eltype(d::PeriodicEuclidean) = eltype(d.periods)
 end
 @inline eval_reduce(::PeriodicEuclidean, s1, s2) = s1 + s2
 @inline eval_end(::PeriodicEuclidean, s) = sqrt(s)
-function evaluate(dist::PeriodicEuclidean, a::T, b::T) where {T <: Real}
+function evaluate(dist::PeriodicEuclidean, a::Real, b::Real)
     p = first(dist.periods)
     d = mod(abs(a - b), p)
     min(d, p - d)
@@ -300,14 +299,14 @@ peuclidean(a::Number, b::Number, p::Real) = evaluate(PeriodicEuclidean([p]), a, 
 @inline eval_op(::Cityblock, ai, bi) = abs(ai - bi)
 @inline eval_reduce(::Cityblock, s1, s2) = s1 + s2
 cityblock(a::AbstractArray, b::AbstractArray) = evaluate(Cityblock(), a, b)
-cityblock(a::T, b::T) where {T <: Number} = evaluate(Cityblock(), a, b)
+cityblock(a::Number, b::Number) = evaluate(Cityblock(), a, b)
 
 # Total variation
 @inline eval_op(::TotalVariation, ai, bi) = abs(ai - bi)
 @inline eval_reduce(::TotalVariation, s1, s2) = s1 + s2
 eval_end(::TotalVariation, s) = s / 2
 totalvariation(a::AbstractArray, b::AbstractArray) = evaluate(TotalVariation(), a, b)
-totalvariation(a::T, b::T) where {T <: Number} = evaluate(TotalVariation(), a, b)
+totalvariation(a::Number, b::Number) = evaluate(TotalVariation(), a, b)
 
 # Chebyshev
 @inline eval_op(::Chebyshev, ai, bi) = abs(ai - bi)
@@ -315,20 +314,20 @@ totalvariation(a::T, b::T) where {T <: Number} = evaluate(TotalVariation(), a, b
 # if only NaN, will output NaN
 @inline Base.@propagate_inbounds eval_start(::Chebyshev, a::AbstractArray, b::AbstractArray) = abs(a[1] - b[1])
 chebyshev(a::AbstractArray, b::AbstractArray) = evaluate(Chebyshev(), a, b)
-chebyshev(a::T, b::T) where {T <: Number} = evaluate(Chebyshev(), a, b)
+chebyshev(a::Number, b::Number) = evaluate(Chebyshev(), a, b)
 
 # Minkowski
 @inline eval_op(dist::Minkowski, ai, bi) = abs(ai - bi).^dist.p
 @inline eval_reduce(::Minkowski, s1, s2) = s1 + s2
 eval_end(dist::Minkowski, s) = s.^(1 / dist.p)
 minkowski(a::AbstractArray, b::AbstractArray, p::Real) = evaluate(Minkowski(p), a, b)
-minkowski(a::T, b::T, p::Real) where {T <: Number} = evaluate(Minkowski(p), a, b)
+minkowski(a::Number, b::Number, p::Real) = evaluate(Minkowski(p), a, b)
 
 # Hamming
 @inline eval_op(::Hamming, ai, bi) = ai != bi ? 1 : 0
 @inline eval_reduce(::Hamming, s1, s2) = s1 + s2
 hamming(a::AbstractArray, b::AbstractArray) = evaluate(Hamming(), a, b)
-hamming(a::T, b::T) where {T <: Number} = evaluate(Hamming(), a, b)
+hamming(a::Number, b::Number) = evaluate(Hamming(), a, b)
 
 # Cosine dist
 @inline function eval_start(::CosineDist, a::AbstractArray{T}, b::AbstractArray{T}) where {T <: Real}
@@ -450,9 +449,8 @@ end
 
 eval_end(::SpanNormDist, s) = s[2] - s[1]
 spannorm_dist(a::AbstractArray, b::AbstractArray) = evaluate(SpanNormDist(), a, b)
-function result_type(dist::SpanNormDist, ::AbstractArray{T1}, ::AbstractArray{T2}) where {T1, T2}
-    typeof(eval_op(dist, one(T1), one(T2)))
-end
+result_type(dist::SpanNormDist, a::AbstractArray, b::AbstractArray) =
+    Base.promote_op(eval_op, SpanNormDist, eltype(a), eltype(b))
 
 
 # Jaccard

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -253,7 +253,7 @@ end
     return eval_end(d, s)
 end
 result_type(dist::UnionMetrics, a::AbstractArray, b::AbstractArray) =
-    Base.promote_op(evaluate, typeof(dist), eltype(a), eltype(b))
+    typeof(evaluate(dist, zero(eltype(a)), zero(eltype(b))))
 
 eval_start(d::UnionMetrics, a::AbstractArray, b::AbstractArray) =
     zero(result_type(d, a, b))
@@ -287,7 +287,8 @@ end
 @inline eval_reduce(::PeriodicEuclidean, s1, s2) = s1 + s2
 @inline eval_end(::PeriodicEuclidean, s) = sqrt(s)
 function evaluate(dist::PeriodicEuclidean, a::Real, b::Real)
-    p = first(dist.periods)
+    periods = dist.periods
+    p = isempty(periods) ? one(eltype(periods)) : first(periods)
     d = mod(abs(a - b), p)
     min(d, p - d)
 end
@@ -450,7 +451,7 @@ end
 eval_end(::SpanNormDist, s) = s[2] - s[1]
 spannorm_dist(a::AbstractArray, b::AbstractArray) = evaluate(SpanNormDist(), a, b)
 result_type(dist::SpanNormDist, a::AbstractArray, b::AbstractArray) =
-    Base.promote_op(eval_op, SpanNormDist, eltype(a), eltype(b))
+    typeof(eval_op(dist, zero(eltype(a)), zero(eltype(b))))
 
 
 # Jaccard

--- a/src/wmetrics.jl
+++ b/src/wmetrics.jl
@@ -40,10 +40,10 @@ Base.eltype(x::UnionWeightedMetrics) = eltype(x.weights)
 ###########################################################
 
 function evaluate(dist::UnionWeightedMetrics, a::Number, b::Number)
-    eval_end(dist, eval_op(dist, a, b, one(eltype(dist))))
+    eval_end(dist, eval_op(dist, a, b, oneunit(eltype(dist))))
 end
 result_type(dist::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray) =
-    typeof(evaluate(dist, zero(eltype(a)), zero(eltype(b))))
+    typeof(evaluate(dist, oneunit(eltype(a)), oneunit(eltype(b))))
 
 @inline function eval_start(d::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray)
     zero(result_type(d, a, b))

--- a/src/wmetrics.jl
+++ b/src/wmetrics.jl
@@ -43,7 +43,7 @@ function evaluate(dist::UnionWeightedMetrics, a::Number, b::Number)
     eval_end(dist, eval_op(dist, a, b, one(eltype(dist))))
 end
 result_type(dist::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray) =
-    Base.promote_op(evaluate, typeof(dist), eltype(a), eltype(b))
+    typeof(evaluate(dist, zero(eltype(a)), zero(eltype(b))))
 
 @inline function eval_start(d::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray)
     zero(result_type(d, a, b))

--- a/src/wmetrics.jl
+++ b/src/wmetrics.jl
@@ -39,12 +39,12 @@ Base.eltype(x::UnionWeightedMetrics) = eltype(x.weights)
 #
 ###########################################################
 
-function evaluate(dist::UnionWeightedMetrics, a::T, b::T) where {T <: Number}
+function evaluate(dist::UnionWeightedMetrics, a::Number, b::Number)
     eval_end(dist, eval_op(dist, a, b, one(eltype(dist))))
 end
-function result_type(dist::UnionWeightedMetrics, ::AbstractArray{T1}, ::AbstractArray{T2}) where {T1, T2}
-    typeof(evaluate(dist, one(T1), one(T2)))
-end
+result_type(dist::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray) =
+    Base.promote_op(evaluate, typeof(dist), eltype(a), eltype(b))
+
 @inline function eval_start(d::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray)
     zero(result_type(d, a, b))
 end


### PR DESCRIPTION
When I started working on this PR, my intention was to fix https://github.com/JuliaStats/Distances.jl/issues/130. Actually only the changes in https://github.com/devmotion/Distances.jl/blob/promote_op/src/common.jl#L115 and https://github.com/devmotion/Distances.jl/blob/promote_op/src/wmetrics.jl#L46 are needed to be able to run successfully
```julia
using Distances, Tracker

Tracker.gradient(x -> sum(pairwise(WeightedSqEuclidean(x), [3 5; 4 6]; dims = 2)), [1, 2])

y, back = Tracker.forward(x -> sum(pairwise(WeightedSqEuclidean([1,2]), x; dims = 2)), [3 5; 4 6])
back(1)
```
BTW, I don't know why but trying to execute
```julia
Tracker.gradient(x -> sum(pairwise(WeightedSqEuclidean([1, 2]), x; dims = 2)), [3 5; 4 6])
```
yields the error message
```julia
ERROR: MethodError: Cannot `convert` an object of type Array{Float64,1} to an object of type SubArray{Float64,1,Array{Float64,2},Tuple{Base.Slice{Base.OneTo{Int64}},Int64},true}                                           
Closest candidates are:
  convert(::Type{T<:AbstractArray}, ::T<:AbstractArray) where T<:AbstractArray at abstractarray.jl:14
  convert(::Type{T<:AbstractArray}, ::LinearAlgebra.Factorization) where T<:AbstractArray at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/LinearAlgebra/src/factorization.jl:46
  convert(::Type{T}, ::T) where T at essentials.jl:154
  ...
```
However, I noticed that due to the quite restrictive type annotations for scalar inputs not only typically scalar evaluation is restricted to inputs of exactly the same type, but for weighted metrics also the vectorized computations are restricted to arguments with elements of exactly the same type. After the simple change to `promote_op` in https://github.com/devmotion/Distances.jl/blob/promote_op/src/wmetrics.jl#L46, this behaviour is still present since in all cases with arguments of different types `result_type` would return `Any`, and hence evaluation breaks as soon as `zero(result_type(...))` is called. Thus I loosened the type annotations of the scalar case to fix this issue.

Moreover, I applied the same changes to the standard metrics.