### PR TITLE
rework result_type

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -25,18 +25,18 @@ abstract type Metric <: SemiMetric end
 # Generic functions
 
 """
-    result_type(::PreMetric, ::Type, ::Type) -> T
-    result_type(::PreMetric, ::AbstractArray, ::AbstractArray) -> T
+    result_type(dist::PreMetric, Ta::Type, Tb::Type) -> T
+    result_type(dist::PreMetric, a::AbstractArray, b::AbstractArray) -> T
 
-The result type `T` is used to pre-allocate the memory of result array.
+Infer the result type of metric `dist` with input type `Ta` and `Tb`, or input
+data `a` and `b`.
 
-```julia-repl
-julia> T = result_type(Euclidean(), Float32, Float64)
-Float64
-julia> r = zeros(T, 2, 2)
-2×2 Array{Float64,2}:
- 0.0  0.0
- 0.0  0.0
+We can use `T` to pre-allocate the memory of result array:
+
+```julia
+T = result_type(dist, a, b)
+r = Matrix{T}(undef, m, n)
+pairwise!(r, dist, a, b, dims=2)
 ```
 """
 result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -24,7 +24,23 @@ abstract type Metric <: SemiMetric end
 
 # Generic functions
 
-result_type(::PreMetric, ::AbstractArray, ::AbstractArray) = Float64
+"""
+    result_type(::PreMetric, ::Type, ::Type) -> T
+    result_type(::PreMetric, ::AbstractArray, ::AbstractArray) -> T
+
+The result type `T` is used to pre-allocate the memory of result array.
+
+```julia-repl
+julia> T = result_type(Euclidean(), Float32, Float64)
+Float64
+julia> r = zeros(T, 2, 2)
+2×2 Array{Float64,2}:
+ 0.0  0.0
+ 0.0  0.0
+```
+"""
+result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback
+result_type(dist::PreMetric, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
 
 
 # Generic column-wise evaluation

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -30,14 +30,6 @@ abstract type Metric <: SemiMetric end
 
 Infer the result type of metric `dist` with input type `Ta` and `Tb`, or input
 data `a` and `b`.
-
-We can use `T` to pre-allocate the memory of result array:
-
-```julia
-T = result_type(dist, a, b)
-r = Matrix{T}(undef, m, n)
-pairwise!(r, dist, a, b, dims=2)
-```
 """
 result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback
 result_type(dist::PreMetric, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -8,8 +8,8 @@ struct SqMahalanobis{T} <: SemiMetric
     qmat::Matrix{T}
 end
 
-result_type(::Mahalanobis{T}, ::AbstractArray, ::AbstractArray) where {T} = T
-result_type(::SqMahalanobis{T}, ::AbstractArray, ::AbstractArray) where {T} = T
+result_type(::Mahalanobis{T}, ::Type, ::Type) where {T} = T
+result_type(::SqMahalanobis{T}, ::Type, ::Type) where {T} = T
 
 # SqMahalanobis
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -252,9 +252,8 @@ end
     end
     return eval_end(d, s)
 end
-result_type(dist::UnionMetrics, a::AbstractArray, b::AbstractArray) =
-    typeof(evaluate(dist, oneunit(eltype(a)), oneunit(eltype(b))))
-
+result_type(dist::UnionMetrics, Ta::Type, Tb::Type) =
+    typeof(evaluate(dist, oneunit(Ta), oneunit(Tb)))
 eval_start(d::UnionMetrics, a::AbstractArray, b::AbstractArray) =
     zero(result_type(d, a, b))
 eval_end(d::UnionMetrics, s) = s
@@ -352,7 +351,7 @@ evaluate(::CorrDist, a::AbstractArray, b::AbstractArray) = cosine_dist(_centrali
 # Ambiguity resolution
 evaluate(::CorrDist, a::Array, b::Array) = cosine_dist(_centralize(a), _centralize(b))
 corr_dist(a::AbstractArray, b::AbstractArray) = evaluate(CorrDist(), a, b)
-result_type(::CorrDist, a::AbstractArray, b::AbstractArray) = result_type(CosineDist(), a, b)
+result_type(::CorrDist, Ta::Type, Tb::Type) = result_type(CosineDist(), Ta, Tb)
 
 # ChiSqDist
 @inline eval_op(::ChiSqDist, ai, bi) = (d = abs2(ai - bi) / (ai + bi); ifelse(ai != bi, d, zero(d)))
@@ -452,9 +451,8 @@ end
 
 eval_end(::SpanNormDist, s) = s[2] - s[1]
 spannorm_dist(a::AbstractArray, b::AbstractArray) = evaluate(SpanNormDist(), a, b)
-result_type(dist::SpanNormDist, a::AbstractArray, b::AbstractArray) =
-    typeof(eval_op(dist, oneunit(eltype(a)), oneunit(eltype(b))))
-
+result_type(dist::SpanNormDist, Ta::Type, Tb::Type) =
+    typeof(eval_op(dist, oneunit(Ta), oneunit(Tb)))
 
 # Jaccard
 

--- a/src/wmetrics.jl
+++ b/src/wmetrics.jl
@@ -42,8 +42,8 @@ Base.eltype(x::UnionWeightedMetrics) = eltype(x.weights)
 function evaluate(dist::UnionWeightedMetrics, a::Number, b::Number)
     eval_end(dist, eval_op(dist, a, b, oneunit(eltype(dist))))
 end
-result_type(dist::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray) =
-    typeof(evaluate(dist, oneunit(eltype(a)), oneunit(eltype(b))))
+result_type(dist::UnionWeightedMetrics, Ta::Type, Tb::Type) =
+    typeof(evaluate(dist, oneunit(Ta), oneunit(Tb)))
 
 @inline function eval_start(d::UnionWeightedMetrics, a::AbstractArray, b::AbstractArray)
     zero(result_type(d, a, b))


### PR DESCRIPTION
The essence of `result_type` is based on the `eltype(a)`, and `result_type(::PreMetric, ::AbstractArray, ::AbstractArray)` only serves as an convenient method.

There are no functionality changes in this commit, only to reorganize the codes to ease future development.

---

For example, in `ImageDistances.jl`, we can easily extend `result_type` to `Colorant` types if we dispatch on `Type`:

```julia
for (ATa, ATb) in ((AbstractGray, AbstractGray),
                   (AbstractGray, Number      ),
                   (Number      , AbstractGray),
                   (PromoteType , PromoteType )) # Union{FixedPoint, Bool}
    @eval function result_type(dist::PreMetric, a::Type{Ta}, b::Type{Tb}) where {Ta<:$ATa, Tb<:$ATb}
        T1 = eltype(floattype(Ta)) # Gray{N0f8} -> Float32
        T2 = eltype(floattype(Tb))
        result_type(dist, T1, T2)
    end
end
```

In the meantime, dispatching on `AbstractArray` would introduces a lot of method ambiguities.