### PR TITLE
remove deprecation of not giving dims

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Note that either of `X` and `Y` can be just a single vector -- then the `colwise
 
 #### Computing pairwise distances
 
-Let `X` and `Y` respectively have `m` and `n` columns. Then the `pairwise` function with the `dims=2` argument computes distances between each pair of columns in `X` and `Y`:
+Let `X` and `Y` respectively have `m` and `n` columns. Then the `pairwise` function argument computes distances between each pair of columns in `X` and `Y`:
 
 ```julia
-R = pairwise(dist, X, Y, dims=2)
+R = pairwise(dist, X, Y)
 ```
 
 In the output, `R` is a matrix of size `(m, n)`, such that `R[i,j]` is the distance between `X[:,i]` and `Y[:,j]`. Computing distances for all pairs using `pairwise` function is often remarkably faster than evaluting for each pair individually.
@@ -93,7 +93,7 @@ In the output, `R` is a matrix of size `(m, n)`, such that `R[i,j]` is the dista
 If you just want to just compute distances between columns of a matrix `X`, you can write
 
 ```julia
-R = pairwise(dist, X, dims=2)
+R = pairwise(dist, X)
 ```
 
 This statement will result in an `m-by-m` matrix, where `R[i,j]` is the distance between `X[:,i]` and `X[:,j]`.
@@ -105,12 +105,12 @@ matrices with observations stored in rows are also supported via the argument `d
 
 #### Computing column-wise and pairwise distances inplace
 
-If the vector/matrix to store the results are pre-allocated, you may use the storage (without creating a new array) using the following syntax (`i` being either `1` or `2`):
+If the vector/matrix to store the results are pre-allocated, you may use the storage (without creating a new array) using the following syntax (`dims` being either `1` or `2`):
 
 ```julia
 colwise!(r, dist, X, Y)
-pairwise!(R, dist, X, Y, dims=i)
-pairwise!(R, dist, X, dims=i)
+pairwise!(R, dist, X, Y, dims=2)
+pairwise!(R, dist, X, dims=2)
 ```
 
 Please pay attention to the difference, the functions for inplace computation are `colwise!` and `pairwise!` (instead of `colwise` and `pairwise`).

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -120,20 +120,9 @@ function _pairwise!(r::AbstractMatrix, metric::SemiMetric, a::AbstractMatrix)
     r
 end
 
-function deprecated_dims(dims::Union{Nothing,Integer})
-    if dims === nothing
-        Base.depwarn("implicit `dims=2` argument now has to be passed explicitly " *
-                     "to specify that distances between columns should be computed",
-                     :pairwise!)
-        return 2
-    else
-        return dims
-    end
-end
-
 """
     pairwise!(r::AbstractMatrix, metric::PreMetric,
-              a::AbstractMatrix, b::AbstractMatrix=a; dims)
+              a::AbstractMatrix, b::AbstractMatrix=a; dims=2)
 
 Compute distances between each pair of rows (if `dims=1`) or columns (if `dims=2`)
 in `a` and `b` according to distance `metric`, and store the result in `r`.
@@ -144,8 +133,7 @@ If a single matrix `a` is provided, compute distances between its rows or column
 """
 function pairwise!(r::AbstractMatrix, metric::PreMetric,
                    a::AbstractMatrix, b::AbstractMatrix;
-                   dims::Union{Nothing,Integer}=nothing)
-    dims = deprecated_dims(dims)
+                   dims::Integer=2)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
     if dims == 1
         na, ma = size(a)
@@ -168,8 +156,7 @@ function pairwise!(r::AbstractMatrix, metric::PreMetric,
 end
 
 function pairwise!(r::AbstractMatrix, metric::PreMetric, a::AbstractMatrix;
-                   dims::Union{Nothing,Integer}=nothing)
-    dims = deprecated_dims(dims)
+                   dims::Integer=2)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
     if dims == 1
         n, m = size(a)
@@ -186,7 +173,7 @@ function pairwise!(r::AbstractMatrix, metric::PreMetric, a::AbstractMatrix;
 end
 
 """
-    pairwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix=a; dims)
+    pairwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix=a; dims=2)
 
 Compute distances between each pair of rows (if `dims=1`) or columns (if `dims=2`)
 in `a` and `b` according to distance `metric`. If a single matrix `a` is provided,
@@ -195,8 +182,7 @@ compute distances between its rows or columns.
 `a` and `b` must have the same numbers of columns if `dims=1`, or of rows if `dims=2`.
 """
 function pairwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix;
-                  dims::Union{Nothing,Integer}=nothing)
-    dims = deprecated_dims(dims)
+                  dims::Integer=2)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
     m = size(a, dims)
     n = size(b, dims)
@@ -205,8 +191,7 @@ function pairwise(metric::PreMetric, a::AbstractMatrix, b::AbstractMatrix;
 end
 
 function pairwise(metric::PreMetric, a::AbstractMatrix;
-                  dims::Union{Nothing,Integer}=nothing)
-    dims = deprecated_dims(dims)
+                  dims::Integer=2)
     dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
     n = size(a, dims)
     r = Matrix{result_type(metric, a, a)}(undef, n, n)


### PR DESCRIPTION
I missed this change. This is really annoying to have to specify. It is clearly documented how we interpret a matrix.