### PR TITLE
Comment on how type hierarchy differs from maths definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ perform computation for half of the pairs, and derive the values immediately for
 `Metric` do not completely follow the definition in mathematics as they do not require the "distance" to be able
 to distinguish between points: for these types `x != y` does not imply
 that `d(x, y) != 0` in general compared to the mathematical
-definition of semi-metric and metric, as this property do not change
+definition of semi-metric and metric, as this property does not change
 computations in practice.
 
 Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
 
 	d(x, z) <= d(x, y) + d(y, z)  for all x, y, z
 
-This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only
-perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of
-*semi-metrics*. Note that the types of `SemiMetric` and
-`Metric` do not completely follow the definition in mathematics as they do not require the "distance" to be able
-to distinguish between points: for these types `x != y` does not imply
-that `d(x, y) != 0` in general compared to the mathematical
-definition of semi-metric and metric, as this property does not change
+This type system has practical significance. For example, when computing pairwise distances
+between a set of vectors, you may only perform computation for half of the pairs, derive the
+values immediately for the remaining half by leveraging the symmetry of *semi-metrics*. Note
+that the types of `SemiMetric` and `Metric` do not completely follow the definition in
+mathematics as they do not require the "distance" to be able to distinguish between points:
+for these types `x != y` does not imply that `d(x, y) != 0` in general compared to the
+mathematical definition of semi-metric and metric, as this property does not change
 computations in practice.
 
 Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.

--- a/README.md
+++ b/README.md
@@ -135,10 +135,12 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
 
 This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only
 perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of
-*semi-metrics*. This is why the type definitions for `SemiMetric` and
-`Metric` do not completely follow the mathematical definition of these
-structures which include positive definiteness: `x != y` does not imply
-that `d(x, y) != 0` in general, as this does not change computations.
+*semi-metrics*. Note that the types of `SemiMetric` and
+`Metric` do not completely follow the definition in mathematics as they do not require the "distance" to be able
+to distinguish between points: for these types `x != y` does not imply
+that `d(x, y) != 0` in general compared to the mathematical
+definition of semi-metric and metric, as this property do not change
+computations in practice.
 
 Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,12 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
 
 	d(x, z) <= d(x, y) + d(y, z)  for all x, y, z
 
-This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of *semi-metrics*.
+This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only
+perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of
+*semi-metrics*. This is why the type definitions for `SemiMetric` and
+`Metric` do not completely follow the mathematical definition of these
+structures which include positive definiteness: `x != y` does not imply
+that `d(x, y) != 0` in general, as this does not change computations.
 
 Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.
 


### PR DESCRIPTION
Add a sentence on how the types `SemiMetric` and `Metric` does not include positive definiteness as in the mathematical definition. It is possible for an object of these types to have  `x != y` and `d(x, y) = 0`.

This follows the discussion of #153.