### PR TITLE
Enhancements: allow OffsetArrays and integer arrays in CosineDist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 julia = "1"
 
 [extras]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "Test"]
+test = ["OffsetArrays", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.8.2"
+version = "0.9.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/common.jl
+++ b/src/common.jl
@@ -91,9 +91,6 @@ end
 #
 ###########################################################
 
-_sqrt(a::AbstractArray{<:Integer}) = sqrt.(a)
-_sqrt(a) = sqrt!(a)
-
 function sqrt!(a::AbstractArray)
     @simd for i in eachindex(a)
         @inbounds a[i] = sqrt(a[i])
@@ -102,12 +99,22 @@ function sqrt!(a::AbstractArray)
 end
 
 function sumsq_percol(a::AbstractMatrix{T}) where {T}
-    m = size(a, 1)
     n = size(a, 2)
     r = Vector{T}(undef, n)
     for j = 1:n
         aj = view(a, :, j)
         r[j] = dot(aj, aj)
+    end
+    return r
+end
+
+function norm_percol(a::AbstractMatrix{T}) where {T}
+    n = size(a, 2)
+    √T = typeof(sqrt(oneunit(T)))
+    r = Vector{√T}(undef, n)
+    for j in 1:n
+        aj = view(a, :, j)
+        r[j] = sqrt(dot(aj, aj))
     end
     return r
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -101,7 +101,7 @@ end
 function sumsq_percol(a::AbstractMatrix{T}) where {T}
     n = size(a, 2)
     r = Vector{T}(undef, n)
-    for j = 1:n
+    @simd for j in 1:n
         aj = view(a, :, j)
         r[j] = dot(aj, aj)
     end
@@ -112,7 +112,7 @@ function norm_percol(a::AbstractMatrix{T}) where {T}
     n = size(a, 2)
     √T = typeof(sqrt(oneunit(T)))
     r = Vector{√T}(undef, n)
-    for j in 1:n
+    @simd for j in 1:n
         aj = view(a, :, j)
         r[j] = sqrt(dot(aj, aj))
     end

--- a/src/common.jl
+++ b/src/common.jl
@@ -91,6 +91,9 @@ end
 #
 ###########################################################
 
+_sqrt(a::AbstractArray{<:Integer}) = sqrt.(a)
+_sqrt(a) = sqrt!(a)
+
 function sqrt!(a::AbstractArray)
     @simd for i in eachindex(a)
         @inbounds a[i] = sqrt(a[i])

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -236,7 +236,7 @@ Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b
     end
     @inbounds begin
         s = eval_start(d, a, b)
-        if IndexStyle(a, b) === IndexLinear() && eachindex(a) == eachindex(b)
+        if IndexStyle(a, b) === IndexLinear() && axes(a) == axes(b)
             @simd for I in eachindex(a, b)
                 ai = a[I]
                 bi = b[I]
@@ -265,7 +265,7 @@ Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b
     end
     @inbounds begin
         s = eval_start(d, a, b)
-        if IndexStyle(a, b, p) === IndexLinear() && eachindex(a) == eachindex(b) == eachindex(p)
+        if IndexStyle(a, b, p) === IndexLinear() && axes(a) == axes(b) == axes(p)
             @simd for I in eachindex(a, b, p)
                 ai = a[I]
                 bi = b[I]

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -236,7 +236,7 @@ Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b
     end
     @inbounds begin
         s = eval_start(d, a, b)
-        if IndexStyle(a, b) === IndexLinear() && axes(a) == axes(b)
+        if (IndexStyle(a, b) === IndexLinear() && eachindex(a) == eachindex(b)) || axes(a) == axes(b)
             @simd for I in eachindex(a, b)
                 ai = a[I]
                 bi = b[I]
@@ -265,7 +265,8 @@ Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b
     end
     @inbounds begin
         s = eval_start(d, a, b)
-        if IndexStyle(a, b, p) === IndexLinear() && axes(a) == axes(b) == axes(p)
+        if (IndexStyle(a, b, p) === IndexLinear() && eachindex(a) == eachindex(b) == eachindex(p)) ||
+                axes(a) == axes(b) == axes(p)
             @simd for I in eachindex(a, b, p)
                 ai = a[I]
                 bi = b[I]

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -786,8 +786,8 @@ function _pairwise!(r::AbstractMatrix, dist::CosineDist,
                     a::AbstractMatrix, b::AbstractMatrix)
     m, na, nb = get_pairwise_dims(r, a, b)
     mul!(r, a', b)
-    ra = _sqrt(sumsq_percol(a))
-    rb = _sqrt(sumsq_percol(b))
+    ra = norm_percol(a)
+    rb = norm_percol(b)
     for j = 1:nb
         @simd for i = 1:na
             @inbounds r[i, j] = max(1 - r[i, j] / (ra[i] * rb[j]), 0)
@@ -798,7 +798,7 @@ end
 function _pairwise!(r::AbstractMatrix, dist::CosineDist, a::AbstractMatrix)
     m, n = get_pairwise_dims(r, a)
     mul!(r, a', a)
-    ra = _sqrt(sumsq_percol(a))
+    ra = norm_percol(a)
     @inbounds for j = 1:n
         @simd for i = j + 1:n
             r[i, j] = max(1 - r[i, j] / (ra[i] * ra[j]), 0)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -236,7 +236,7 @@ Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b
     end
     @inbounds begin
         s = eval_start(d, a, b)
-        if IndexStyle(a, b) === IndexLinear() || size(a) == size(b)
+        if IndexStyle(a, b) === IndexLinear() && eachindex(a) == eachindex(b)
             @simd for I in eachindex(a, b)
                 ai = a[I]
                 bi = b[I]
@@ -265,8 +265,8 @@ Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b
     end
     @inbounds begin
         s = eval_start(d, a, b)
-        if IndexStyle(a, b, p) === IndexLinear() || size(a) == size(b)
-            @simd for I in eachindex(a, b)
+        if IndexStyle(a, b, p) === IndexLinear() && eachindex(a) == eachindex(b) == eachindex(p)
+            @simd for I in eachindex(a, b, p)
                 ai = a[I]
                 bi = b[I]
                 pi = p[I]
@@ -786,8 +786,8 @@ function _pairwise!(r::AbstractMatrix, dist::CosineDist,
                     a::AbstractMatrix, b::AbstractMatrix)
     m, na, nb = get_pairwise_dims(r, a, b)
     mul!(r, a', b)
-    ra = sqrt!(sumsq_percol(a))
-    rb = sqrt!(sumsq_percol(b))
+    ra = _sqrt(sumsq_percol(a))
+    rb = _sqrt(sumsq_percol(b))
     for j = 1:nb
         @simd for i = 1:na
             @inbounds r[i, j] = max(1 - r[i, j] / (ra[i] * rb[j]), 0)
@@ -798,7 +798,7 @@ end
 function _pairwise!(r::AbstractMatrix, dist::CosineDist, a::AbstractMatrix)
     m, n = get_pairwise_dims(r, a)
     mul!(r, a', a)
-    ra = sqrt!(sumsq_percol(a))
+    ra = _sqrt(sumsq_percol(a))
     @inbounds for j = 1:n
         @simd for i = j + 1:n
             r[i, j] = max(1 - r[i, j] / (ra[i] * ra[j]), 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Distances
 
 using Test
 using LinearAlgebra
+using OffsetArrays
 using Random
 using Statistics
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -504,8 +504,8 @@ function test_pairwise(dist, x, y, T)
             rxx[i, j] = dist(x[:, i], x[:, j])
         end
         # As earlier, we have small rounding errors in accumulations
-        @test pairwise(dist, x, y) ≈ rxy
-        @test pairwise(dist, x) ≈ rxx
+        @test pairwise(dist, x, y, dims=2) ≈ rxy
+        @test pairwise(dist, x, dims=2) ≈ rxx
         @test pairwise(dist, x, y, dims=2) ≈ rxy
         @test pairwise(dist, x, dims=2) ≈ rxx
         @test pairwise(dist, permutedims(x), permutedims(y), dims=1) ≈ rxy
@@ -570,16 +570,16 @@ end
 
 @testset "Euclidean precision" begin
     X = [0.1 0.2; 0.3 0.4; -0.1 -0.1]
-    pd = pairwise(Euclidean(1e-12), X, X)
+    pd = pairwise(Euclidean(1e-12), X, X, dims=2)
     @test pd[1, 1] == 0
     @test pd[2, 2] == 0
-    pd = pairwise(Euclidean(1e-12), X)
+    pd = pairwise(Euclidean(1e-12), X, dims=2)
     @test pd[1, 1] == 0
     @test pd[2, 2] == 0
-    pd = pairwise(SqEuclidean(1e-12), X, X)
+    pd = pairwise(SqEuclidean(1e-12), X, X, dims=2)
     @test pd[1, 1] == 0
     @test pd[2, 2] == 0
-    pd = pairwise(SqEuclidean(1e-12), X)
+    pd = pairwise(SqEuclidean(1e-12), X, dims=2)
     @test pd[1, 1] == 0
     @test pd[2, 2] == 0
 end

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -170,6 +170,7 @@ end
             x_int, y_int = Int64.(x), Int64.(y)
             @test cosine_dist(x_int, y_int) == (1.0 - 112.0 / sqrt(19530.0))
             @test corr_dist(x, y) ≈ cosine_dist(x .- mean(x), vec(y) .- mean(y))
+            @test corr_dist(OffsetVector(x, -1:length(x)-2), y) == corr_dist(x, y)
             @test chisq_dist(x, y) == sum((x - vec(y)).^2 ./ (x + vec(y)))
             @test spannorm_dist(x, y) == maximum(x - vec(y)) - minimum(x - vec(y))
 
@@ -536,6 +537,7 @@ end
     test_pairwise(Hamming(), A, B, T)
 
     test_pairwise(CosineDist(), X, Y, T)
+    test_pairwise(CosineDist(), A, B, T)
     test_pairwise(CorrDist(), X, Y, T)
 
     test_pairwise(ChiSqDist(), X, Y, T)


### PR DESCRIPTION
Closes #106. Closes #93.

The logic in the `UnionMetric`'s `_evaluate` wasn't able to distinguish the case when one array had offset indices. But I'm not sure if the logic here is too strict. I don't see any slowdown, though benchmarking is a bit nontrivial. I've used this for benchmarking:
```julia
using Distances, OffsetArrays, BenchmarkTools

for m in (2, 10, 30)
  x, y, p = rand(m), rand(m), rand(m)
  d = Euclidean()
  dp = PeriodicEuclidean(p)
  @btime $d($x, $y);
  @btime $dp($x, $y);
end
```
Timings vary a bit, but I don't see a clear pattern of regression. Also, the infamous benchmark from #107 is clearly won by `colwise`.

Moreover
```julia
julia> using Distances, OffsetArrays

julia> x, y = rand(10), rand(10)
([0.02801362061758983, 0.8939414820779741, 0.711232152659703, 0.9910084998815372, 0.09319994918278351, 0.4034886165223559, 0.22832132159907648, 0.6169286534167804, 0.9309683705377529, 0.6998361254000887], [0.2479258273830649, 0.2573826000306132, 0.765649154420025, 0.06495363114307429, 0.41802555664920504, 0.8972858186710049, 0.4236709655992299, 0.3596080783013793, 0.4169463881238391, 0.7490678314251886])

julia> corr_dist(x,y)
1.1160543248280592

julia> xoff = OffsetVector(x, -5:4)
10-element OffsetArray(::Array{Float64,1}, -5:4) with eltype Float64 with indices -5:4:
 0.02801362061758983
 0.8939414820779741
 0.711232152659703
 0.9910084998815372
 0.09319994918278351
 0.4034886165223559
 0.22832132159907648
 0.6169286534167804
 0.9309683705377529
 0.6998361254000887

julia> corr_dist(xoff, y)
1.1160543248280592
```
and
```julia
julia> using Distances

julia> A = rand(1:100, (100, 100));

julia> pairwise(CosineDist(), A; dims=2)
100×100 Array{Float64,2}:
...
```