### PR TITLE
add default value of Earth's radius to Haversine

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Each distance corresponds to a distance type. The type name and the correspondin
 |  SpanNormDist        |  `spannorm_dist(x, y)`     | `max(x - y) - min(x - y)` |
 |  BhattacharyyaDist   |  `bhattacharyya(x, y)`     | `-log(sum(sqrt(x .* y) / sqrt(sum(x) * sum(y)))` |
 |  HellingerDist       |  `hellinger(x, y) `        | `sqrt(1 - sum(sqrt(x .* y) / sqrt(sum(x) * sum(y))))` |
-|  Haversine           |  `haversine(x, y, r)`      | [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula) |
+|  Haversine           |  `haversine(x, y, r = 6371000)`      | [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula) |
 |  SphericalAngle      |  `spherical_angle(x, y)`   | [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula) |
 |  Mahalanobis         |  `mahalanobis(x, y, Q)`    | `sqrt((x - y)' * Q * (x - y))` |
 |  SqMahalanobis       |  `sqmahalanobis(x, y, Q)`  | `(x - y)' * Q * (x - y)` |

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -1,10 +1,12 @@
 """
-    Haversine(radius)
+    Haversine([radius])
 
 The haversine distance between two locations on a sphere of given `radius`.
 
 Locations are described with longitude and latitude in degrees.
 The computed distance has the same units as that of the radius.
+The default value is 6371000 meters, which is the mean volumetric
+radius of Earth (source https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html).
 """
 struct Haversine{T<:Real} <: Metric
     radius::T

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -9,6 +9,7 @@ The computed distance has the same units as that of the radius.
 struct Haversine{T<:Real} <: Metric
     radius::T
 end
+Haversine() = Haversine(6378137.0)
 
 function (dist::Haversine)(x, y)
     length(x) == length(y) == 2 || haversine_error(dist)

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -9,7 +9,7 @@ The computed distance has the same units as that of the radius.
 struct Haversine{T<:Real} <: Metric
     radius::T
 end
-Haversine() = Haversine(6378137.0)
+Haversine() = Haversine(6371000.0)
 
 function (dist::Haversine)(x, y)
     length(x) == length(y) == 2 || haversine_error(dist)
@@ -31,7 +31,7 @@ function (dist::Haversine)(x, y)
     2 * dist.radius * asin( min(√a, one(a)) ) # take care of floating point errors
 end
 
-haversine(x, y, radius::Real) = Haversine(radius)(x, y)
+haversine(x, y, radius::Real = 6371000.0) = Haversine(radius)(x, y)
 
 @noinline haversine_error(dist) = throw(ArgumentError("expected both inputs to have length 2 in $dist distance"))
 

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -9,7 +9,7 @@ The computed distance has the same units as that of the radius.
 struct Haversine{T<:Real} <: Metric
     radius::T
 end
-Haversine() = Haversine(6371000.0)
+Haversine() = Haversine(Float32(6371000))
 
 function (dist::Haversine)(x, y)
     length(x) == length(y) == 2 || haversine_error(dist)
@@ -31,7 +31,7 @@ function (dist::Haversine)(x, y)
     2 * dist.radius * asin( min(√a, one(a)) ) # take care of floating point errors
 end
 
-haversine(x, y, radius::Real = 6371000.0) = Haversine(radius)(x, y)
+haversine(x, y, radius::Real = Float32(6371000)) = Haversine(radius)(x, y)
 
 @noinline haversine_error(dist) = throw(ArgumentError("expected both inputs to have length 2 in $dist distance"))
 


### PR DESCRIPTION
I don't think it should be necessary to look up the radius of Earth every time one wants to use the Haversine formula, so I've added the equatorial radius of Earth in meters as a default. I hope most imperial unit users will agree that metric is a reasonable default for scientific libraries. Of course Earth has different radii depending on where it is measured, as it isn't a perfect sphere. Uses sensitive to this should use more specific values. FYI this same default value is used in R. source https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html