### PR TITLE
simplify result_type on UnionMetrics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -213,12 +213,12 @@ for dist in weightedmetrics
     @eval parameters(d::$dist) = d.weights
 end
 
-result_type(dist::UnionMetrics, a::AbstractArray, b::AbstractArray) =
-    result_type(dist, a, b, parameters(dist))
-result_type(dist::UnionMetrics, a::AbstractArray, b::AbstractArray, ::Nothing) =
-    typeof(_evaluate(dist, oneunit(eltype(a)), oneunit(eltype(b))))
-result_type(dist::UnionMetrics, a::AbstractArray, b::AbstractArray, p) =
-    typeof(_evaluate(dist, oneunit(eltype(a)), oneunit(eltype(b)), oneunit(eltype(p))))
+result_type(dist::UnionMetrics, ::Type{Ta}, ::Type{Tb}) where {Ta,Tb} =
+    result_type(dist, Ta, Tb, parameters(dist))
+result_type(dist::UnionMetrics, ::Type{Ta}, ::Type{Tb}, ::Nothing) where {Ta,Tb} =
+    typeof(_evaluate(dist, oneunit(Ta), oneunit(Tb)))
+result_type(dist::UnionMetrics, ::Type{Ta}, ::Type{Tb}, p) where {Ta,Tb} =
+    typeof(_evaluate(dist, oneunit(Ta), oneunit(Tb), oneunit(eltype(p))))
 
 Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b::AbstractArray)
     _evaluate(d, a, b, parameters(d))
@@ -261,7 +261,7 @@ Base.@propagate_inbounds function _evaluate(d::UnionMetrics, a::AbstractArray, b
         throw(DimensionMismatch("arrays have length $(length(a)) but parameters have length $(length(p))."))
     end
     if length(a) == 0
-        return zero(result_type(d, a, b, p))
+        return zero(result_type(d, a, b))
     end
     @inbounds begin
         s = eval_start(d, a, b)


### PR DESCRIPTION
#150 has unfortunately broken the glue code in ImageDistances because it specializes the `result_type` for `UnionMetrics` without defining the method for `Type`.

https://github.com/JuliaStats/Distances.jl/blob/44036b573ec85287022f4368c4e1e279698bd031/src/generic.jl#L35

This PR adds these two methods:

```julia
result_type(dist::UnionMetrics, ::Type{Ta}, ::Type{Tb}, ::Nothing)
result_type(dist::UnionMetrics, ::Type{Ta}, ::Type{Tb}, p)
```

and https://github.com/JuliaImages/ImageDistances.jl/pull/46 gets fixed by this.