### PR TITLE
Fix negative values in the pairwise computations of SqMahalanobis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -53,7 +53,7 @@ function _pairwise!(r::AbstractMatrix, dist::SqMahalanobis{T},
 
     for j = 1:nb
         @simd for i = 1:na
-            @inbounds r[i, j] = sa2[i] + sb2[j] - 2 * r[i, j]
+            @inbounds r[i, j] = max(sa2[i] + sb2[j] - 2 * r[i, j], 0)
         end
     end
     r
@@ -74,7 +74,7 @@ function _pairwise!(r::AbstractMatrix, dist::SqMahalanobis{T},
         end
         r[j, j] = 0
         for i = (j + 1):n
-            @inbounds r[i, j] = sa2[i] + sa2[j] - 2 * r[i, j]
+            @inbounds r[i, j] = max(sa2[i] + sa2[j] - 2 * r[i, j], 0)
         end
     end
     r

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -586,7 +586,7 @@ end
     @test pd[2, 2] == 0
 end
 
-@testset "Euclidean non-negativity" begin
+@testset "non-negativity" begin
     X = [0.3 0.3 + eps()]
 
     @test all(x -> x >= 0, pairwise(SqEuclidean(), X; dims = 2))
@@ -595,6 +595,8 @@ end
     @test all(x -> x >= 0, pairwise(Euclidean(), X, X; dims = 2))
     @test all(x -> x >= 0, pairwise(WeightedSqEuclidean([1.0]), X; dims = 2))
     @test all(x -> x >= 0, pairwise(WeightedSqEuclidean([1.0]), X, X; dims = 2))
+    @test all(x -> x >= 0, pairwise(SqMahalanobis(ones(1, 1)), X; dims = 2))
+    @test all(x -> x >= 0, pairwise(SqMahalanobis(ones(1, 1)), X, X; dims = 2))
 end
 
 @testset "Bregman Divergence" begin


### PR DESCRIPTION
Fixes negative values in the pairwise computations with SqMahalanobis, in the same way as done for the (weighted) (Sq)Euclidean distances (https://github.com/JuliaStats/Distances.jl/pull/161) and CosineDist.

On master:
```julia
julia> using Distances

julia> a = [0.3 0.3 + eps()]
1×2 Array{Float64,2}:
 0.3  0.3

julia> pairwise(SqMahalanobis(ones(1, 1)), a; dims = 2)
2×2 Array{Float64,2}:
  0.0          -2.77556e-17
 -2.77556e-17   0.0

julia> pairwise(SqMahalanobis(ones(1, 1)), a, a; dims = 2)
2×2 Array{Float64,2}:
  0.0          -2.77556e-17
 -2.77556e-17   0.0
```

With this PR:
```julia
julia> using Distances

julia> a = [0.3 0.3 + eps()]
1×2 Array{Float64,2}:
 0.3  0.3

julia> pairwise(SqMahalanobis(ones(1, 1)), a; dims = 2)
2×2 Array{Float64,2}:
 0.0  0.0
 0.0  0.0

julia> pairwise(SqMahalanobis(ones(1, 1)), a, a; dims = 2)
2×2 Array{Float64,2}:
 0.0  0.0
 0.0  0.0
```