### PR TITLE
relax result_type dist types

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -26,14 +26,16 @@ evaluate(dist::PreMetric, a, b) = dist(a, b)
 # Generic functions
 
 """
-    result_type(dist::PreMetric, Ta::Type, Tb::Type) -> T
-    result_type(dist::PreMetric, a::AbstractArray, b::AbstractArray) -> T
+    result_type(dist, Ta::Type, Tb::Type) -> T
+    result_type(dist, a::AbstractArray, b::AbstractArray) -> T
 
 Infer the result type of metric `dist` with input type `Ta` and `Tb`, or input
 data `a` and `b`.
 """
-result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback
-result_type(dist::PreMetric, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
+result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback in Distances
+# for outside extensibility to other packages
+result_type(f, a::Type, b::Type) = typeof(f(oneunit(a), oneunit(b)))
+result_type(dist, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
 
 
 # Generic column-wise evaluation

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -1,5 +1,20 @@
 # Unit tests for Distances
 
+@testset "result_type" begin
+    struct FooDist <: PreMetric end
+    foodist(a, b) = a + b
+    for (Ta, Tb) in [
+        (Int, Int),
+        (Int, Float64),
+        (Float32, Float32),
+        (Float32, Float64),
+    ]
+        A, B = rand(Ta, 2, 3), rand(Tb, 2, 3)
+        @test result_type(FooDist(), A, B) == result_type(FooDist(), Ta, Tb) == Float64
+        @test result_type(foodist, A, B) == result_type(foodist, Ta, Tb) == typeof(foodist(oneunit(Ta), oneunit(Tb)))
+    end
+end
+
 function test_metricity(dist, x, y, z)
     @testset "Test metricity of $(typeof(dist))" begin
         @test dist(x, y) == evaluate(dist, x, y)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -1,7 +1,8 @@
 # Unit tests for Distances
 
+struct FooDist <: PreMetric end # Julia 1.0 Compat: struct definition must be put in global scope
+
 @testset "result_type" begin
-    struct FooDist <: PreMetric end
     foodist(a, b) = a + b
     for (Ta, Tb) in [
         (Int, Int),


### PR DESCRIPTION
I'm working on an extension package to Distances to handle massive pointwise calculation where the output is of size at O(m^2*n^2), and I find it could be quite useful to reuse this `result_type` here, so this PR is just relaxing it a bit to accept any kind of function `dist`.

Not very sure if this is a wanted change. I can make up my own `result_type` function there but I guess to get this done here it would be helpful also to other potential usages.

For Distances own purpose, now it is possible to

```julia
julia> result_type(euclidean, Int, Int)
Float64
```