### PR TITLE
Relax type signature for `result_type` and allow it to act on numbers

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -33,10 +33,11 @@ Infer the result type of metric `dist` with input type `Ta` and `Tb`, or input
 data `a` and `b`.
 """
 result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback in Distances
-# for outside extensibility to other packages
-result_type(f, a::Type, b::Type) = typeof(f(oneunit(a), oneunit(b)))
-result_type(dist, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
+result_type(f, a::Type, b::Type) = typeof(f(oneunit(a), oneunit(b))) # don't require `PreMetric` subtyping
 
+# Promote Arays and Numbers to types
+result_type(dist, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
+result_type(dist, a::Number, b::Number) = result_type(dist, typeof(a), typeof(b))
 
 # Generic column-wise evaluation
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -26,14 +26,16 @@ evaluate(dist::PreMetric, a, b) = dist(a, b)
 # Generic functions
 
 """
-    result_type(dist::PreMetric, Ta::Type, Tb::Type) -> T
-    result_type(dist::PreMetric, a::AbstractArray, b::AbstractArray) -> T
+    result_type(dist, Ta::Type, Tb::Type) -> T
+    result_type(dist, a::AbstractArray, b::AbstractArray) -> T
 
 Infer the result type of metric `dist` with input type `Ta` and `Tb`, or input
 data `a` and `b`.
 """
-result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback
-result_type(dist::PreMetric, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
+result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback in Distances
+# for outside extensibility to other packages
+result_type(f, a::Type, b::Type) = typeof(f(oneunit(a), oneunit(b)))
+result_type(dist, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
 
 
 # Generic column-wise evaluation

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -36,7 +36,6 @@ data `a` and `b`.
 result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback in Distances
 result_type(f, a::Type, b::Type) = typeof(f(oneunit(a), oneunit(b))) # don't require `PreMetric` subtyping
 
-# Promote Arrays and Numbers to types
 result_type(dist, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
 result_type(dist, a::Number, b::Number) = result_type(dist, typeof(a), typeof(b))
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -28,6 +28,7 @@ evaluate(dist::PreMetric, a, b) = dist(a, b)
 """
     result_type(dist, Ta::Type, Tb::Type) -> T
     result_type(dist, a::AbstractArray, b::AbstractArray) -> T
+    result_type(dist, a::Number, b::Number) -> T
 
 Infer the result type of metric `dist` with input type `Ta` and `Tb`, or input
 data `a` and `b`.

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -36,7 +36,7 @@ data `a` and `b`.
 result_type(::PreMetric, ::Type, ::Type) = Float64 # fallback in Distances
 result_type(f, a::Type, b::Type) = typeof(f(oneunit(a), oneunit(b))) # don't require `PreMetric` subtyping
 
-# Promote Arays and Numbers to types
+# Promote Arrays and Numbers to types
 result_type(dist, a::AbstractArray, b::AbstractArray) = result_type(dist, eltype(a), eltype(b))
 result_type(dist, a::Number, b::Number) = result_type(dist, typeof(a), typeof(b))
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -1,5 +1,21 @@
 # Unit tests for Distances
 
+struct FooDist <: PreMetric end # Julia 1.0 Compat: struct definition must be put in global scope
+
+@testset "result_type" begin
+    foodist(a, b) = a + b
+    for (Ta, Tb) in [
+        (Int, Int),
+        (Int, Float64),
+        (Float32, Float32),
+        (Float32, Float64),
+    ]
+        A, B = rand(Ta, 2, 3), rand(Tb, 2, 3)
+        @test result_type(FooDist(), A, B) == result_type(FooDist(), Ta, Tb) == Float64
+        @test result_type(foodist, A, B) == result_type(foodist, Ta, Tb) == typeof(foodist(oneunit(Ta), oneunit(Tb)))
+    end
+end
+
 function test_metricity(dist, x, y, z)
     @testset "Test metricity of $(typeof(dist))" begin
         @test dist(x, y) == evaluate(dist, x, y)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -13,6 +13,10 @@ struct FooDist <: PreMetric end # Julia 1.0 Compat: struct definition must be pu
         A, B = rand(Ta, 2, 3), rand(Tb, 2, 3)
         @test result_type(FooDist(), A, B) == result_type(FooDist(), Ta, Tb) == Float64
         @test result_type(foodist, A, B) == result_type(foodist, Ta, Tb) == typeof(foodist(oneunit(Ta), oneunit(Tb)))
+
+        a, b = rand(Ta), rand(Tb)
+        @test result_type(FooDist(), a, b) == result_type(FooDist(), Ta, Tb) == Float64
+        @test result_type(foodist, a, b) == result_type(foodist, Ta, Tb) == typeof(foodist(oneunit(Ta), oneunit(Tb)))
     end
 end
 


### PR DESCRIPTION
Redo of #185 along with defining `result_type` for `Number`s so that `result_type` can act on objects generically as discussed in #190.

Closes #190