### PR TITLE
Draft for deprecation route

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.1'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "1"
+julia = "1.1"
 
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -11,9 +11,9 @@ export
 
     # generic functions
     result_type,
-    colwise,
+    zipwise,
     pairwise,
-    colwise!,
+    zipwise!,
     pairwise!,
     evaluate,
 

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -11,9 +11,9 @@ export
 
     # generic functions
     result_type,
-    zipwise,
+    colwise,
     pairwise,
-    zipwise!,
+    colwise!,
     pairwise!,
     evaluate,
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,18 +6,6 @@
 #
 ###########################################################
 
-function get_common_ncols(a::AbstractMatrix, b::AbstractMatrix)
-    na = size(a, 2)
-    size(b, 2) == na || throw(DimensionMismatch("The number of columns in a and b must match."))
-    return na
-end
-
-function get_common_length(a, b)
-    n = length(a)
-    length(b) == n || throw(DimensionMismatch("The lengths of a and b must match."))
-    return n
-end
-
 function get_pairwise_dims(r::AbstractMatrix, a::AbstractMatrix, b::AbstractMatrix)
     ma, na = size(a)
     mb, nb = size(b)

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -32,20 +32,6 @@ end
 
 sqmahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = SqMahalanobis(Q)(a, b)
 
-function zipwise!(r::AbstractArray, dist::SqMahalanobis, a::AbstractMatrix, b::AbstractMatrix)
-    Q = dist.qmat
-    m, n = get_colwise_dims(size(Q, 1), r, a, b)
-    z = a - b
-    dot_percol!(r, Q * z, z)
-end
-
-function zipwise!(r::AbstractArray, dist::SqMahalanobis, a::AbstractVector, b::AbstractMatrix)
-    Q = dist.qmat
-    m, n = get_colwise_dims(size(Q, 1), r, a, b)
-    z = a .- b
-    dot_percol!(r, Q * z, z)
-end
-
 function _pairwise!(r::AbstractMatrix, dist::SqMahalanobis,
                     a::AbstractMatrix, b::AbstractMatrix)
     Q = dist.qmat
@@ -94,14 +80,6 @@ function (dist::Mahalanobis)(a::AbstractVector, b::AbstractVector)
 end
 
 mahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = Mahalanobis(Q)(a, b)
-
-function zipwise!(r::AbstractArray, dist::Mahalanobis, a::AbstractMatrix, b::AbstractMatrix)
-    sqrt!(zipwise!(r, SqMahalanobis(dist.qmat), a, b))
-end
-
-function zipwise!(r::AbstractArray, dist::Mahalanobis, a::AbstractVector, b::AbstractMatrix)
-    sqrt!(zipwise!(r, SqMahalanobis(dist.qmat), a, b))
-end
 
 function _pairwise!(r::AbstractMatrix, dist::Mahalanobis,
                     a::AbstractMatrix, b::AbstractMatrix)

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -32,18 +32,17 @@ end
 
 sqmahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = SqMahalanobis(Q)(a, b)
 
-function colwise!(r::AbstractArray, dist::SqMahalanobis, a::AbstractMatrix, b::AbstractMatrix)
+function zipwise!(r::AbstractArray, dist::SqMahalanobis, a::AbstractMatrix, b::AbstractMatrix)
     Q = dist.qmat
     m, n = get_colwise_dims(size(Q, 1), r, a, b)
     z = a - b
     dot_percol!(r, Q * z, z)
 end
 
-function colwise!(r::AbstractArray, dist::SqMahalanobis, a::AbstractVector, b::AbstractMatrix)
+function zipwise!(r::AbstractArray, dist::SqMahalanobis, a::AbstractVector, b::AbstractMatrix)
     Q = dist.qmat
     m, n = get_colwise_dims(size(Q, 1), r, a, b)
     z = a .- b
-    Qz = Q * z
     dot_percol!(r, Q * z, z)
 end
 
@@ -96,12 +95,12 @@ end
 
 mahalanobis(a::AbstractVector, b::AbstractVector, Q::AbstractMatrix) = Mahalanobis(Q)(a, b)
 
-function colwise!(r::AbstractArray, dist::Mahalanobis, a::AbstractMatrix, b::AbstractMatrix)
-    sqrt!(colwise!(r, SqMahalanobis(dist.qmat), a, b))
+function zipwise!(r::AbstractArray, dist::Mahalanobis, a::AbstractMatrix, b::AbstractMatrix)
+    sqrt!(zipwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
-function colwise!(r::AbstractArray, dist::Mahalanobis, a::AbstractVector, b::AbstractMatrix)
-    sqrt!(colwise!(r, SqMahalanobis(dist.qmat), a, b))
+function zipwise!(r::AbstractArray, dist::Mahalanobis, a::AbstractVector, b::AbstractMatrix)
+    sqrt!(zipwise!(r, SqMahalanobis(dist.qmat), a, b))
 end
 
 function _pairwise!(r::AbstractMatrix, dist::Mahalanobis,

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -786,11 +786,11 @@ function _pairwise!(r::AbstractMatrix, dist::Euclidean, a::AbstractMatrix)
 end
 
 # Weighted Euclidean
-function colwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractMatrix, b::AbstractMatrix)
-    sqrt!(colwise!(r, WeightedSqEuclidean(dist.weights), a, b))
+function zipwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractMatrix, b::AbstractMatrix)
+    sqrt!(zipwise!(r, WeightedSqEuclidean(dist.weights), a, b))
 end
-function colwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractVector, b::AbstractMatrix)
-    sqrt!(colwise!(r, WeightedSqEuclidean(dist.weights), a, b))
+function zipwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractVector, b::AbstractMatrix)
+    sqrt!(zipwise!(r, WeightedSqEuclidean(dist.weights), a, b))
 end
 function _pairwise!(r::AbstractMatrix, dist::WeightedEuclidean,
                     a::AbstractMatrix, b::AbstractMatrix)
@@ -802,7 +802,7 @@ end
 
 # CosineDist
 
-function _pairwise!(r::AbstractMatrix, dist::CosineDist,
+function _pairwise!(r::AbstractMatrix, ::CosineDist,
                     a::AbstractMatrix, b::AbstractMatrix)
     m, na, nb = get_pairwise_dims(r, a, b)
     mul!(r, a', b)
@@ -815,7 +815,7 @@ function _pairwise!(r::AbstractMatrix, dist::CosineDist,
     end
     r
 end
-function _pairwise!(r::AbstractMatrix, dist::CosineDist, a::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix, ::CosineDist, a::AbstractMatrix)
     m, n = get_pairwise_dims(r, a)
     mul!(r, a', a)
     ra = norm_percol(a)
@@ -838,16 +838,16 @@ end
 #    of `_centralize` -- ~4x speed up
 _centralize_colwise(x::AbstractVector) = x .- mean(x)
 _centralize_colwise(x::AbstractMatrix) = x .- mean(x, dims=1)
-function colwise!(r::AbstractVector, dist::CorrDist, a::AbstractMatrix, b::AbstractMatrix)
+function colwise!(r::AbstractArray, ::CorrDist, a::AbstractMatrix, b::AbstractMatrix)
     colwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
 end
-function colwise!(r::AbstractVector, dist::CorrDist, a::AbstractVector, b::AbstractMatrix)
+function colwise!(r::AbstractArray, ::CorrDist, a::AbstractVector, b::AbstractMatrix)
     colwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
 end
-function _pairwise!(r::AbstractMatrix, dist::CorrDist,
+function _pairwise!(r::AbstractMatrix, ::CorrDist,
                     a::AbstractMatrix, b::AbstractMatrix)
     _pairwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
 end
-function _pairwise!(r::AbstractMatrix, dist::CorrDist, a::AbstractMatrix)
+function _pairwise!(r::AbstractMatrix, ::CorrDist, a::AbstractMatrix)
     _pairwise!(r, CosineDist(), _centralize_colwise(a))
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -786,12 +786,6 @@ function _pairwise!(r::AbstractMatrix, dist::Euclidean, a::AbstractMatrix)
 end
 
 # Weighted Euclidean
-function zipwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractMatrix, b::AbstractMatrix)
-    sqrt!(zipwise!(r, WeightedSqEuclidean(dist.weights), a, b))
-end
-function zipwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractVector, b::AbstractMatrix)
-    sqrt!(zipwise!(r, WeightedSqEuclidean(dist.weights), a, b))
-end
 function _pairwise!(r::AbstractMatrix, dist::WeightedEuclidean,
                     a::AbstractMatrix, b::AbstractMatrix)
     sqrt!(_pairwise!(r, WeightedSqEuclidean(dist.weights), a, b))

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -345,10 +345,10 @@ end # testset
     @test_throws DimensionMismatch mahalanobis(q, q, Q)
     mat23 = [0.3 0.2 0.0; 0.1 0.0 0.4]
     mat22 = [0.3 0.2; 0.1 0.4]
-    @test_throws DimensionMismatch zipwise!(mat23, Euclidean(), mat23, mat23)
-    @test_throws DimensionMismatch zipwise!(mat23, Euclidean(), mat23, q)
-    @test_throws DimensionMismatch zipwise!(mat23, Euclidean(), mat23, mat22)
-    @test_throws DimensionMismatch zipwise!(mat23, Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), mat23, mat22)
+    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat23)
+    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, q)
+    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat22)
+    @test_throws DimensionMismatch colwise!(mat23, Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), mat23, mat22)
     @test_throws DimensionMismatch Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x)([1, 2, 3], [1, 2])
     @test_throws DimensionMismatch Bregman(x -> sqeuclidean(x, zero(x)), x -> [1, 2])([1, 2, 3], [1, 2, 3])
 end # testset
@@ -460,8 +460,8 @@ end
 end #testset
 
 
-function test_zipwise(dist, x, y, T)
-    @testset "Zipwise test for $(typeof(dist))" begin
+function test_colwise(dist, x, y, T)
+    @testset "Colwise test for $(typeof(dist))" begin
         n = size(x, 2)
         r1 = zeros(T, n)
         r2 = zeros(T, n)
@@ -472,10 +472,10 @@ function test_zipwise(dist, x, y, T)
             r3[j] = dist(x[:, j], y[:, 1])
         end
         # ≈ and all( .≈ ) seem to behave slightly differently for F64
-        @test all(zipwise(dist, x, y) .≈ r1)
-        @test all(zipwise(dist, (x[:,i] for i in axes(x, 2)), (y[:,i] for i in axes(y, 2))) .≈ r1)
-        @test all(zipwise(dist, x[:, 1], y) .≈ r2)
-        @test all(zipwise(dist, x, y[:, 1]) .≈ r3)
+        @test all(colwise(dist, x, y) .≈ r1)
+        @test all(colwise(dist, (x[:,i] for i in axes(x, 2)), (y[:,i] for i in axes(y, 2))) .≈ r1)
+        @test all(colwise(dist, x[:, 1], y) .≈ r2)
+        @test all(colwise(dist, x, y[:, 1]) .≈ r3)
     end
 end
 
@@ -494,47 +494,47 @@ end
         P[P[:, i] .< median(P[:, i]) / 2, i] .= 0.0
     end
 
-    test_zipwise(SqEuclidean(), X, Y, T)
-    test_zipwise(Euclidean(), X, Y, T)
-    test_zipwise(Cityblock(), X, Y, T)
-    test_zipwise(TotalVariation(), X, Y, T)
-    test_zipwise(Chebyshev(), X, Y, T)
-    test_zipwise(Minkowski(2.5), X, Y, T)
-    test_zipwise(Hamming(), A, B, T)
-    test_zipwise(Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), X, Y, T);
+    test_colwise(SqEuclidean(), X, Y, T)
+    test_colwise(Euclidean(), X, Y, T)
+    test_colwise(Cityblock(), X, Y, T)
+    test_colwise(TotalVariation(), X, Y, T)
+    test_colwise(Chebyshev(), X, Y, T)
+    test_colwise(Minkowski(2.5), X, Y, T)
+    test_colwise(Hamming(), A, B, T)
+    test_colwise(Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), X, Y, T);
 
-    test_zipwise(CosineDist(), X, Y, T)
-    test_zipwise(CorrDist(), X, Y, T)
+    test_colwise(CosineDist(), X, Y, T)
+    test_colwise(CorrDist(), X, Y, T)
 
-    test_zipwise(ChiSqDist(), X, Y, T)
-    test_zipwise(KLDivergence(), P, Q, T)
-    test_zipwise(RenyiDivergence(0.0), P, Q, T)
-    test_zipwise(RenyiDivergence(1.0), P, Q, T)
-    test_zipwise(RenyiDivergence(Inf), P, Q, T)
-    test_zipwise(RenyiDivergence(0.5), P, Q, T)
-    test_zipwise(RenyiDivergence(2), P, Q, T)
-    test_zipwise(RenyiDivergence(10), P, Q, T)
-    test_zipwise(JSDivergence(), P, Q, T)
-    test_zipwise(SpanNormDist(), X, Y, T)
+    test_colwise(ChiSqDist(), X, Y, T)
+    test_colwise(KLDivergence(), P, Q, T)
+    test_colwise(RenyiDivergence(0.0), P, Q, T)
+    test_colwise(RenyiDivergence(1.0), P, Q, T)
+    test_colwise(RenyiDivergence(Inf), P, Q, T)
+    test_colwise(RenyiDivergence(0.5), P, Q, T)
+    test_colwise(RenyiDivergence(2), P, Q, T)
+    test_colwise(RenyiDivergence(10), P, Q, T)
+    test_colwise(JSDivergence(), P, Q, T)
+    test_colwise(SpanNormDist(), X, Y, T)
 
-    test_zipwise(BhattacharyyaDist(), X, Y, T)
-    test_zipwise(HellingerDist(), X, Y, T)
-    test_zipwise(BrayCurtis(), X, Y, T)
+    test_colwise(BhattacharyyaDist(), X, Y, T)
+    test_colwise(HellingerDist(), X, Y, T)
+    test_colwise(BrayCurtis(), X, Y, T)
 
     w = rand(T, m)
 
-    test_zipwise(WeightedSqEuclidean(w), X, Y, T)
-    test_zipwise(WeightedEuclidean(w), X, Y, T)
-    test_zipwise(WeightedCityblock(w), X, Y, T)
-    test_zipwise(WeightedMinkowski(w, 2.5), X, Y, T)
-    test_zipwise(WeightedHamming(w), A, B, T)
-    test_zipwise(PeriodicEuclidean(w), X, Y, T)
+    test_colwise(WeightedSqEuclidean(w), X, Y, T)
+    test_colwise(WeightedEuclidean(w), X, Y, T)
+    test_colwise(WeightedCityblock(w), X, Y, T)
+    test_colwise(WeightedMinkowski(w, 2.5), X, Y, T)
+    test_colwise(WeightedHamming(w), A, B, T)
+    test_colwise(PeriodicEuclidean(w), X, Y, T)
 
     Q = rand(T, m, m)
     Q = Q * Q'  # make sure Q is positive-definite
 
-    test_zipwise(SqMahalanobis(Q), X, Y, T)
-    test_zipwise(Mahalanobis(Q), X, Y, T)
+    test_colwise(SqMahalanobis(Q), X, Y, T)
+    test_colwise(Mahalanobis(Q), X, Y, T)
 end
 
 function test_pairwise(dist, x, y, T)
@@ -723,18 +723,18 @@ end
 end
 
 #=
-@testset "zero allocation zipwise!" begin
+@testset "zero allocation colwise!" begin
     d = Euclidean()
     a = rand(2, 41)
     b = rand(2, 41)
     z = zeros(41)
-    zipwise!(z, d, a, b)
+    colwise!(z, d, a, b)
     # This fails when bounds checking is enforced
     bounds = Base.JLOptions().check_bounds
     if bounds == 0
-        @test (@allocated zipwise!(z, d, a, b)) == 0
+        @test (@allocated colwise!(z, d, a, b)) == 0
     else
-        @test_broken (@allocated zipwise!(z, d, a, b)) == 0
+        @test_broken (@allocated colwise!(z, d, a, b)) == 0
     end
 end
 =#

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -345,10 +345,10 @@ end # testset
     @test_throws DimensionMismatch mahalanobis(q, q, Q)
     mat23 = [0.3 0.2 0.0; 0.1 0.0 0.4]
     mat22 = [0.3 0.2; 0.1 0.4]
-    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat23)
-    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, q)
-    @test_throws DimensionMismatch colwise!(mat23, Euclidean(), mat23, mat22)
-    @test_throws DimensionMismatch colwise!(mat23, Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), mat23, mat22)
+    @test_throws DimensionMismatch zipwise!(mat23, Euclidean(), mat23, mat23)
+    @test_throws DimensionMismatch zipwise!(mat23, Euclidean(), mat23, q)
+    @test_throws DimensionMismatch zipwise!(mat23, Euclidean(), mat23, mat22)
+    @test_throws DimensionMismatch zipwise!(mat23, Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), mat23, mat22)
     @test_throws DimensionMismatch Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x)([1, 2, 3], [1, 2])
     @test_throws DimensionMismatch Bregman(x -> sqeuclidean(x, zero(x)), x -> [1, 2])([1, 2, 3], [1, 2, 3])
 end # testset
@@ -460,8 +460,8 @@ end
 end #testset
 
 
-function test_colwise(dist, x, y, T)
-    @testset "Colwise test for $(typeof(dist))" begin
+function test_zipwise(dist, x, y, T)
+    @testset "Zipwise test for $(typeof(dist))" begin
         n = size(x, 2)
         r1 = zeros(T, n)
         r2 = zeros(T, n)
@@ -472,10 +472,10 @@ function test_colwise(dist, x, y, T)
             r3[j] = dist(x[:, j], y[:, 1])
         end
         # ≈ and all( .≈ ) seem to behave slightly differently for F64
-        @test all(colwise(dist, x, y) .≈ r1)
-        @test all(colwise(dist, (x[:,i] for i in axes(x, 2)), (y[:,i] for i in axes(y, 2))) .≈ r1)
-        @test all(colwise(dist, x[:, 1], y) .≈ r2)
-        @test all(colwise(dist, x, y[:, 1]) .≈ r3)
+        @test all(zipwise(dist, x, y) .≈ r1)
+        @test all(zipwise(dist, (x[:,i] for i in axes(x, 2)), (y[:,i] for i in axes(y, 2))) .≈ r1)
+        @test all(zipwise(dist, x[:, 1], y) .≈ r2)
+        @test all(zipwise(dist, x, y[:, 1]) .≈ r3)
     end
 end
 
@@ -494,47 +494,47 @@ end
         P[P[:, i] .< median(P[:, i]) / 2, i] .= 0.0
     end
 
-    test_colwise(SqEuclidean(), X, Y, T)
-    test_colwise(Euclidean(), X, Y, T)
-    test_colwise(Cityblock(), X, Y, T)
-    test_colwise(TotalVariation(), X, Y, T)
-    test_colwise(Chebyshev(), X, Y, T)
-    test_colwise(Minkowski(2.5), X, Y, T)
-    test_colwise(Hamming(), A, B, T)
-    test_colwise(Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), X, Y, T);
+    test_zipwise(SqEuclidean(), X, Y, T)
+    test_zipwise(Euclidean(), X, Y, T)
+    test_zipwise(Cityblock(), X, Y, T)
+    test_zipwise(TotalVariation(), X, Y, T)
+    test_zipwise(Chebyshev(), X, Y, T)
+    test_zipwise(Minkowski(2.5), X, Y, T)
+    test_zipwise(Hamming(), A, B, T)
+    test_zipwise(Bregman(x -> sqeuclidean(x, zero(x)), x -> 2*x), X, Y, T);
 
-    test_colwise(CosineDist(), X, Y, T)
-    test_colwise(CorrDist(), X, Y, T)
+    test_zipwise(CosineDist(), X, Y, T)
+    test_zipwise(CorrDist(), X, Y, T)
 
-    test_colwise(ChiSqDist(), X, Y, T)
-    test_colwise(KLDivergence(), P, Q, T)
-    test_colwise(RenyiDivergence(0.0), P, Q, T)
-    test_colwise(RenyiDivergence(1.0), P, Q, T)
-    test_colwise(RenyiDivergence(Inf), P, Q, T)
-    test_colwise(RenyiDivergence(0.5), P, Q, T)
-    test_colwise(RenyiDivergence(2), P, Q, T)
-    test_colwise(RenyiDivergence(10), P, Q, T)
-    test_colwise(JSDivergence(), P, Q, T)
-    test_colwise(SpanNormDist(), X, Y, T)
+    test_zipwise(ChiSqDist(), X, Y, T)
+    test_zipwise(KLDivergence(), P, Q, T)
+    test_zipwise(RenyiDivergence(0.0), P, Q, T)
+    test_zipwise(RenyiDivergence(1.0), P, Q, T)
+    test_zipwise(RenyiDivergence(Inf), P, Q, T)
+    test_zipwise(RenyiDivergence(0.5), P, Q, T)
+    test_zipwise(RenyiDivergence(2), P, Q, T)
+    test_zipwise(RenyiDivergence(10), P, Q, T)
+    test_zipwise(JSDivergence(), P, Q, T)
+    test_zipwise(SpanNormDist(), X, Y, T)
 
-    test_colwise(BhattacharyyaDist(), X, Y, T)
-    test_colwise(HellingerDist(), X, Y, T)
-    test_colwise(BrayCurtis(), X, Y, T)
+    test_zipwise(BhattacharyyaDist(), X, Y, T)
+    test_zipwise(HellingerDist(), X, Y, T)
+    test_zipwise(BrayCurtis(), X, Y, T)
 
     w = rand(T, m)
 
-    test_colwise(WeightedSqEuclidean(w), X, Y, T)
-    test_colwise(WeightedEuclidean(w), X, Y, T)
-    test_colwise(WeightedCityblock(w), X, Y, T)
-    test_colwise(WeightedMinkowski(w, 2.5), X, Y, T)
-    test_colwise(WeightedHamming(w), A, B, T)
-    test_colwise(PeriodicEuclidean(w), X, Y, T)
+    test_zipwise(WeightedSqEuclidean(w), X, Y, T)
+    test_zipwise(WeightedEuclidean(w), X, Y, T)
+    test_zipwise(WeightedCityblock(w), X, Y, T)
+    test_zipwise(WeightedMinkowski(w, 2.5), X, Y, T)
+    test_zipwise(WeightedHamming(w), A, B, T)
+    test_zipwise(PeriodicEuclidean(w), X, Y, T)
 
     Q = rand(T, m, m)
     Q = Q * Q'  # make sure Q is positive-definite
 
-    test_colwise(SqMahalanobis(Q), X, Y, T)
-    test_colwise(Mahalanobis(Q), X, Y, T)
+    test_zipwise(SqMahalanobis(Q), X, Y, T)
+    test_zipwise(Mahalanobis(Q), X, Y, T)
 end
 
 function test_pairwise(dist, x, y, T)
@@ -550,10 +550,10 @@ function test_pairwise(dist, x, y, T)
             rxx[i, j] = dist(x[:, i], x[:, j])
         end
         # As earlier, we have small rounding errors in accumulations
-        @test pairwise(dist, x, y, dims=2) ≈ rxy
-        @test pairwise(dist, x, dims=2) ≈ rxx
-        @test pairwise(dist, permutedims(x), permutedims(y), dims=1) ≈ rxy
-        @test pairwise(dist, permutedims(x), dims=1) ≈ rxx
+        @test pairwise(dist, eachcol(x), eachcol(y)) ≈ rxy
+        @test pairwise(dist, eachcol(x)) ≈ rxx
+        @test pairwise(dist, eachrow(permutedims(x)), eachrow(permutedims(y))) ≈ rxy
+        @test pairwise(dist, eachrow(permutedims(x))) ≈ rxx
         vecx = (x[:, i] for i in 1:nx)
         vecy = (y[:, i] for i in 1:ny)
         for (vecx, vecy) in ((vecx, vecy), (collect(vecx), collect(vecy)))
@@ -628,9 +628,9 @@ function test_scalar_pairwise(dist, x, y, T)
         # As earlier, we have small rounding errors in accumulations
         @test pairwise(dist, x, y) ≈ rxy
         @test pairwise(dist, x) ≈ rxx
-        @test pairwise(dist, permutedims(x), permutedims(y), dims=2) ≈ rxy
-        @test pairwise(dist, permutedims(x), dims=2) ≈ rxx
-        @test_throws DimensionMismatch pairwise(dist, permutedims(x), permutedims(y), dims=1)
+        @test pairwise(dist, eachcol(permutedims(x)), eachcol(permutedims(y))) ≈ rxy
+        @test pairwise(dist, eachcol(permutedims(x))) ≈ rxx
+        @test_throws DimensionMismatch pairwise(dist, eachrow(permutedims(x)), eachrow(permutedims(y)))
     end
 end
 
@@ -723,18 +723,18 @@ end
 end
 
 #=
-@testset "zero allocation colwise!" begin
+@testset "zero allocation zipwise!" begin
     d = Euclidean()
     a = rand(2, 41)
     b = rand(2, 41)
     z = zeros(41)
-    colwise!(z, d, a, b)
+    zipwise!(z, d, a, b)
     # This fails when bounds checking is enforced
     bounds = Base.JLOptions().check_bounds
     if bounds == 0
-        @test (@allocated colwise!(z, d, a, b)) == 0
+        @test (@allocated zipwise!(z, d, a, b)) == 0
     else
-        @test_broken (@allocated colwise!(z, d, a, b)) == 0
+        @test_broken (@allocated zipwise!(z, d, a, b)) == 0
     end
 end
 =#


### PR DESCRIPTION
I went a ahead and started a draft for how one could proceed further, making the package more/solely iterator-based. A few thoughts and suggestions:

* replace `rowwise` by `zipwise` and ask for `eachcol` or `eachrow` iterators, thus removing the necessity to even think about things like a `rowwise` command (cf. #138);
* essentially remove the `dims` keyword in `pairwise`; this is currently only half way, because some specializations do require an underlying matrix, but assuming we are typically given row- or column-iterators, we don't have access to that matrix currently (for the full way version, this requires JuliaLang/julia#32310).

This is breaking, and could form one piece of a transitional version, bumped in the minor version. In a next step, we could remove the matrix-based legacy functions, except those needed for performance reasons, which requires (a) JuliaLang/julia#32310 and (b) a lower Julia bound v1.6/1.7(?), depending on where this feature is included.