### PR TITLE
Clean up README

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ equally well obtained by
 r = colwise(dist, eachcol(X), eachcol(Y))
 ```
 
-Equally simple, the analogous "rowwise" distance computation can be obtained done via
+Equally simple, the analogous "rowwise" distance computation can be obtained via
 
 ```julia
 r = colwise(dist, eachrow(X), eachrow(Y))

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ definitions of the distances are listed in the following table.
 |  JSDivergence        |  `js_divergence(p, q)`     | `KL(p, m) / 2 + KL(p, m) / 2 with m = (p + q) / 2` |
 |  SpanNormDist        |  `spannorm_dist(x, y)`     | `max(x - y) - min(x - y)` |
 |  BhattacharyyaDist   |  `bhattacharyya(x, y)`     | `-log(sum(sqrt(x .* y) / sqrt(sum(x) * sum(y)))` |
-|  HellingerDist       |  `hellinger(x, y) `        | `sqrt(1 - sum(sqrt(x .* y) / sqrt(sum(x) * sum(y))))` |
+|  HellingerDist       |  `hellinger(x, y)`        | `sqrt(1 - sum(sqrt(x .* y) / sqrt(sum(x) * sum(y))))` |
 |  Haversine           |  `haversine(x, y, r = 6_371_000)`      | [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula) |
 |  SphericalAngle      |  `spherical_angle(x, y)`   | [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula) |
 |  Mahalanobis         |  `mahalanobis(x, y, Q)`    | `sqrt((x - y)' * Q * (x - y))` |

--- a/README.md
+++ b/README.md
@@ -256,39 +256,37 @@ replicated using the script in `benchmark/print_table.jl`.
 
 ### Column-wise benchmark
 
-The table below compares the performance (measured in terms of average elapsed
-time of each iteration) of a straightforward loop implementation and an
-implementation specialized to `[Sq]Mahalanobis` provided in *Distances.jl*.
-The task in each iteration is to compute a specific distance between corresponding
-columns in two `200-by-10000` matrices.
+Generically, column-wise distances are computed using a straightforward loop
+implementation. For `[Sq]Mahalanobis`, however, specialized methods are
+provided in *Distances.jl*, and the table below compares the performance
+(measured in terms of average elapsed time of each iteration) of the generic
+to the specialized implementation. The task in each iteration is to compute a
+specific distance between corresponding columns in two `200-by-10000` matrices.
 
-|  distance  |  loop  |  colwise  |  gain  |
-|----------- | -------| ----------| -------|
+|  distance     | loop      |  colwise   |  gain       |
+|---------------|-----------|------------|-------------|
 | SqMahalanobis | 0.089470s |  0.014424s |  **6.2027** |
-| Mahalanobis | 0.090882s |  0.014096s |  **6.4475** |
+| Mahalanobis   | 0.090882s |  0.014096s |  **6.4475** |
 
 ### Pairwise benchmark
 
-The table below compares the performance (measured in terms of average elapsed
-time of each iteration) of a straightforward loop implementation and certain
-specialized implementations provided in *Distances.jl*. The task in each iteration
-is to compute a specific distance in a pairwise manner between columns in a
-`100-by-200` and `100-by-250` matrices, which will result in a `200-by-250`
-distance matrix.
+Generically, pairwise distances are computed using a straightforward loop
+implementation. For distances of which a major part of the computation is a
+quadratic form, however, the performance can be drastically improved by restructuring
+the computation and delegating the core part to `GEMM` in *BLAS*. The table below
+compares the performance (measured in terms of average elapsed time of each
+iteration) of generic to the specialized implementations provided in *Distances.jl*.
+The task in each iteration is to compute a specific distance in a pairwise manner
+between columns in a `100-by-200` and `100-by-250` matrices, which will result in
+a `200-by-250` distance matrix.
 
-|  distance  |  loop  |  pairwise  |  gain  |
-|----------- | -------| ----------| -------|
-| SqEuclidean | 0.001273s |  0.000124s | **10.2290** |
-| Euclidean | 0.001445s |  0.000194s |  **7.4529** |
-| CosineDist | 0.001928s |  0.000149s | **12.9543** |
-| CorrDist | 0.016837s |  0.000187s | **90.1854** |
-| WeightedSqEuclidean | 0.001603s |  0.000143s | **11.2119** |
-| WeightedEuclidean | 0.001811s |  0.000238s |  **7.6032** |
-| SqMahalanobis | 0.308990s |  0.000248s | **1248.1892** |
-| Mahalanobis | 0.313415s |  0.000346s | **906.1836** |
-
-For distances of which a major part of the computation is a quadratic form
-(e.g. *Euclidean*, *CosineDist*, *[Sq]Mahalanobis*), the performance can be
-drastically improved by restructuring the computation and delegating the core
-part to `GEMM` in *BLAS*. The use of this strategy can lead to dramatic
-performance gain over simple loops; see the the table above.
+|  distance             |  loop     |  pairwise  |  gain  |
+|---------------------- | --------- | -----------| -------|
+| SqEuclidean           | 0.001273s |  0.000124s | **10.2290** |
+| Euclidean             | 0.001445s |  0.000194s |  **7.4529** |
+| CosineDist            | 0.001928s |  0.000149s | **12.9543** |
+| CorrDist              | 0.016837s |  0.000187s | **90.1854** |
+| WeightedSqEuclidean   | 0.001603s |  0.000143s | **11.2119** |
+| WeightedEuclidean     | 0.001811s |  0.000238s |  **7.6032** |
+| SqMahalanobis         | 0.308990s |  0.000248s | **1248.1892** |
+| Mahalanobis           | 0.313415s |  0.000346s | **906.1836** |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Distances.jl
 
-[![Build Status](https://github.com/JuliaStats/Distances.jl/workflows/CI/badge.svg)](https://github.com/JuliaStats/Distances.jl/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/JuliaStats/Distances.jl/workflows/CI/badge.svg?branch=master)](https://github.com/JuliaStats/Distances.jl/actions?query=workflow%3ACI+branch%3Amaster)
 [![Coverage Status](http://codecov.io/github/JuliaStats/Distances.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaStats/Distances.jl?branch=master)
 
 A Julia package for evaluating distances(metrics) between vectors.

--- a/README.md
+++ b/README.md
@@ -301,8 +301,8 @@ columns in two `200-by-10000` matrices.
 
 |  distance  |  loop  |  colwise  |  gain  |
 |----------- | -------| ----------| -------|
-| SqMahalanobis | 0.089470s |  0.014424s |  6.2027 |
-| Mahalanobis | 0.090882s |  0.014096s |  6.4475 |
+| SqMahalanobis | 0.089470s |  0.014424s |  **6.2027** |
+| Mahalanobis | 0.090882s |  0.014096s |  **6.4475** |
 
 ### Pairwise benchmark
 
@@ -316,7 +316,7 @@ distance matrix.
 |  distance  |  loop  |  pairwise  |  gain  |
 |----------- | -------| ----------| -------|
 | SqEuclidean | 0.001273s |  0.000124s | **10.2290** |
-| Euclidean | 0.001444s |  0.000201s |  **7.1991** |
+| Euclidean | 0.001445s |  0.000194s |  **7.4529** |
 | CosineDist | 0.001928s |  0.000149s | **12.9543** |
 | CorrDist | 0.016837s |  0.000187s | **90.1854** |
 | WeightedSqEuclidean | 0.001603s |  0.000143s | **11.2119** |
@@ -325,7 +325,7 @@ distance matrix.
 | Mahalanobis | 0.313415s |  0.000346s | **906.1836** |
 
 For distances of which a major part of the computation is a quadratic form
-(e.g. *Euclidean*, *CosineDist*, *Mahalanobis*), the performance can be
+(e.g. *Euclidean*, *CosineDist*, *[Sq]Mahalanobis*), the performance can be
 drastically improved by restructuring the computation and delegating the core
 part to `GEMM` in *BLAS*. The use of this strategy can lead to dramatic
 performance gain over simple loops; see the the table above.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ for these types `x != y` does not imply that `d(x, y) != 0` in general compared 
 mathematical definition of semi-metric and metric, as this property does not change
 computations in practice.
 
-Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.
+Each distance corresponds to a distance type. The type name and the corresponding mathematical
+definitions of the distances are listed in the following table.
 
 | type name            |  convenient syntax         | math definition     |
 | -------------------- | -------------------------- | --------------------|
@@ -280,92 +281,49 @@ julia> pairwise(Euclidean(1e-12), x, x)
 
 ## Benchmarks
 
-The implementation has been carefully optimized based on benchmarks. The script in `benchmark/benchmarks.jl` defines a benchmark suite
-for a variety of distances, under column-wise and pairwise settings.
+The implementation has been carefully optimized based on benchmarks. The script in
+`benchmark/benchmarks.jl` defines a benchmark suite for a variety of distances,
+under column-wise and pairwise settings.
 
-Here are benchmarks obtained running Julia 1.0 on a computer with a dual-core Intel Core i5-2300K processor @ 2.3 GHz.
-The tables below can be replicated using the script in `benchmark/print_table.jl`.
+Here are benchmarks obtained running Julia 1.5 on a computer with a quad-core Intel
+Core i5-2300K processor @ 3.2 GHz. Extended versions of the tables below can be
+replicated using the script in `benchmark/print_table.jl`.
 
 ### Column-wise benchmark
 
 The table below compares the performance (measured in terms of average elapsed
-time of each iteration) of a straightforward loop implementation and an optimized
-implementation provided in *Distances.jl*. The task in each iteration is to
-compute a specific distance between corresponding columns in two `200-by-10000`
-matrices.
+time of each iteration) of a straightforward loop implementation and an
+implementation specialized to `[Sq]Mahalanobis` provided in *Distances.jl*.
+The task in each iteration is to compute a specific distance between corresponding
+columns in two `200-by-10000` matrices.
 
 |  distance  |  loop  |  colwise  |  gain  |
 |----------- | -------| ----------| -------|
-| SqEuclidean | 0.004432s |  0.001049s |  4.2270 |
-| Euclidean | 0.004537s |  0.001054s |  4.3031 |
-| PeriodicEuclidean | 0.012092s |  0.006714s |  1.8011 |
-| Cityblock | 0.004515s |  0.001060s |  4.2585 |
-| TotalVariation | 0.004496s |  0.001062s |  4.2337 |
-| Chebyshev | 0.009123s |  0.005034s |  1.8123 |
-| Minkowski | 0.047573s |  0.042508s |  1.1191 |
-| Hamming | 0.004355s |  0.001099s |  3.9638 |
-| CosineDist | 0.006432s |  0.002282s |  2.8185 |
-| CorrDist | 0.010273s |  0.012500s |  0.8219 |
-| ChiSqDist | 0.005291s |  0.001271s |  4.1635 |
-| KLDivergence | 0.031491s |  0.025643s |  1.2281 |
-| RenyiDivergence | 0.052420s |  0.048075s |  1.0904 |
-| RenyiDivergence | 0.017317s |  0.009023s |  1.9193 |
-| JSDivergence | 0.047905s |  0.044006s |  1.0886 |
-| BhattacharyyaDist | 0.007761s |  0.003796s |  2.0445 |
-| HellingerDist | 0.007636s |  0.003665s |  2.0836 |
-| WeightedSqEuclidean | 0.004550s |  0.001151s |  3.9541 |
-| WeightedEuclidean | 0.004687s |  0.001168s |  4.0125 |
-| WeightedCityblock | 0.004493s |  0.001157s |  3.8849 |
-| WeightedMinkowski | 0.049442s |  0.042145s |  1.1732 |
-| WeightedHamming | 0.004431s |  0.001153s |  3.8440 |
-| SqMahalanobis | 0.082493s |  0.019843s |  4.1574 |
-| Mahalanobis | 0.082180s |  0.019618s |  4.1891 |
-| BrayCurtis | 0.004464s |  0.001121s |  3.9809 |
+| SqMahalanobis | 0.089470s |  0.014424s |  6.2027 |
+| Mahalanobis | 0.090882s |  0.014096s |  6.4475 |
 
-We can see that using `colwise` instead of a simple loop yields considerable
-gain (2x - 4x), especially when the internal computation of each distance is
-simple. Nonetheless, when the computation of a single distance is heavy enough
-(e.g. *KLDivergence*,  *RenyiDivergence*), the gain is not as significant.
-
-#### Pairwise benchmark
+### Pairwise benchmark
 
 The table below compares the performance (measured in terms of average elapsed
-time of each iteration) of a straightforward loop implementation and an optimized
-implementation provided in *Distances.jl*. The task in each iteration is to
-compute a specific distance in a pairwise manner between columns in a
+time of each iteration) of a straightforward loop implementation and certain
+specialized implementations provided in *Distances.jl*. The task in each iteration
+is to compute a specific distance in a pairwise manner between columns in a
 `100-by-200` and `100-by-250` matrices, which will result in a `200-by-250`
 distance matrix.
 
 |  distance  |  loop  |  pairwise  |  gain  |
 |----------- | -------| ----------| -------|
-| SqEuclidean | 0.012498s |  0.000170s | **73.6596** |
-| Euclidean | 0.012583s |  0.000257s | 48.9628 |
-| PeriodicEuclidean | 0.030935s |  0.017572s |  1.7605 |
-| Cityblock | 0.012416s |  0.000910s | 13.6464 |
-| TotalVariation | 0.012763s |  0.000959s | 13.3080 |
-| Chebyshev | 0.023800s |  0.012042s |  1.9763 |
-| Minkowski | 0.121388s |  0.107333s |  1.1310 |
-| Hamming | 0.012171s |  0.000689s | 17.6538 |
-| CosineDist | 0.017474s |  0.000214s | **81.6546** |
-| CorrDist | 0.028195s |  0.000259s | **108.7360** |
-| ChiSqDist | 0.014372s |  0.003129s |  4.5932 |
-| KLDivergence | 0.079669s |  0.063491s |  1.2548 |
-| RenyiDivergence | 0.134093s |  0.117737s |  1.1389 |
-| RenyiDivergence | 0.047658s |  0.024960s |  1.9094 |
-| JSDivergence | 0.121999s |  0.110984s |  1.0993 |
-| BhattacharyyaDist | 0.021788s |  0.009414s |  2.3145 |
-| HellingerDist | 0.020735s |  0.008784s |  2.3606 |
-| WeightedSqEuclidean | 0.012671s |  0.000186s | **68.0345** |
-| WeightedEuclidean | 0.012867s |  0.000276s | **46.6634** |
-| WeightedCityblock | 0.012803s |  0.001539s |  8.3200 |
-| WeightedMinkowski | 0.127386s |  0.107257s |  1.1877 |
-| WeightedHamming | 0.012240s |  0.001462s |  8.3747 |
-| SqMahalanobis | 0.214285s |  0.000330s | **650.0722** |
-| Mahalanobis | 0.197294s |  0.000420s | **470.2354** |
-| BrayCurtis | 0.012872s |  0.001489s |  8.6456 |
+| SqEuclidean | 0.001273s |  0.000124s | **10.2290** |
+| Euclidean | 0.001444s |  0.000201s |  **7.1991** |
+| CosineDist | 0.001928s |  0.000149s | **12.9543** |
+| CorrDist | 0.016837s |  0.000187s | **90.1854** |
+| WeightedSqEuclidean | 0.001603s |  0.000143s | **11.2119** |
+| WeightedEuclidean | 0.001811s |  0.000238s |  **7.6032** |
+| SqMahalanobis | 0.308990s |  0.000248s | **1248.1892** |
+| Mahalanobis | 0.313415s |  0.000346s | **906.1836** |
 
 For distances of which a major part of the computation is a quadratic form
 (e.g. *Euclidean*, *CosineDist*, *Mahalanobis*), the performance can be
 drastically improved by restructuring the computation and delegating the core
-part to `GEMM` in *BLAS*. The use of this strategy can easily lead to 100x
-performance gain over simple loops (see the highlighted part of the table above).
+part to `GEMM` in *BLAS*. The use of this strategy can lead to dramatic
+performance gain over simple loops; see the the table above.

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -57,7 +57,7 @@ function evaluate_colwise(dist, x, y)
     T = typeof(evaluate(dist, x[:, 1], y[:, 1]))
     r = Vector{T}(undef, n)
     for j = 1:n
-        r[j] = evaluate(dist, x[:, j], y[:, j])
+        r[j] = @views evaluate(dist, x[:, j], y[:, j])
     end
     return r
 end
@@ -109,8 +109,8 @@ function evaluate_pairwise(dist, x, y)
     T = typeof(evaluate(dist, x[:, 1], y[:, 1]))
     r = Matrix{T}(undef, nx, ny)
     for j = 1:ny
-        for i = 1:nx
-            r[i, j] = evaluate(dist, x[:, i], y[:, j])
+        @inbounds for i = 1:nx
+            r[i, j] = @views evaluate(dist, x[:, i], y[:, j])
         end
     end
     return r

--- a/src/common.jl
+++ b/src/common.jl
@@ -84,16 +84,6 @@ function sqrt!(a::AbstractArray)
     a
 end
 
-function sumsq_percol(a::AbstractMatrix{T}) where {T}
-    n = size(a, 2)
-    r = Vector{T}(undef, n)
-    @simd for j in 1:n
-        aj = view(a, :, j)
-        r[j] = dot(aj, aj)
-    end
-    return r
-end
-
 function norm_percol(a::AbstractMatrix{T}) where {T}
     n = size(a, 2)
     √T = typeof(sqrt(oneunit(T)))

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -665,15 +665,15 @@ function _pairwise!(r::AbstractMatrix, dist::Union{SqEuclidean,Euclidean}, a::Ab
             end
         else
             for i = (j + 1):n
-            selfterms = sa2[i] + sa2j
-            v = max(selfterms - 2 * r[i, j], 0)
-            if v < threshT * selfterms
-                v = zero(v)
-                for k = 1:m
-                    v += (a[k, i] - a[k, j])^2
+                selfterms = sa2[i] + sa2j
+                v = max(selfterms - 2 * r[i, j], 0)
+                if v < threshT * selfterms
+                    v = zero(v)
+                    for k = 1:m
+                        v += (a[k, i] - a[k, j])^2
+                    end
                 end
-            end
-            r[i, j] = eval_end(dist, v)
+                r[i, j] = eval_end(dist, v)
             end
         end
     end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -786,12 +786,6 @@ function _pairwise!(r::AbstractMatrix, dist::Euclidean, a::AbstractMatrix)
 end
 
 # Weighted Euclidean
-function colwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractMatrix, b::AbstractMatrix)
-    sqrt!(colwise!(r, WeightedSqEuclidean(dist.weights), a, b))
-end
-function colwise!(r::AbstractArray, dist::WeightedEuclidean, a::AbstractVector, b::AbstractMatrix)
-    sqrt!(colwise!(r, WeightedSqEuclidean(dist.weights), a, b))
-end
 function _pairwise!(r::AbstractMatrix, dist::WeightedEuclidean,
                     a::AbstractMatrix, b::AbstractMatrix)
     sqrt!(_pairwise!(r, WeightedSqEuclidean(dist.weights), a, b))
@@ -838,12 +832,6 @@ end
 #    of `_centralize` -- ~4x speed up
 _centralize_colwise(x::AbstractVector) = x .- mean(x)
 _centralize_colwise(x::AbstractMatrix) = x .- mean(x, dims=1)
-function colwise!(r::AbstractArray, ::CorrDist, a::AbstractMatrix, b::AbstractMatrix)
-    colwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
-end
-function colwise!(r::AbstractArray, ::CorrDist, a::AbstractVector, b::AbstractMatrix)
-    colwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))
-end
 function _pairwise!(r::AbstractMatrix, ::CorrDist,
                     a::AbstractMatrix, b::AbstractMatrix)
     _pairwise!(r, CosineDist(), _centralize_colwise(a), _centralize_colwise(b))


### PR DESCRIPTION
I started fixing the badges, and soon realized the README could use a little clean-up. Now it mentions the iterator-interface. I wonder whether we should keep the colwise benchmarks. After all, few metrics have a specialized implementation, so we do have a "simple loop implementation", and the speed-up shown results actually from using views in the generic methods. That's something that a user implementing her/his own naive loop might as well have used, so the real benefit from specialized methods is restricted to the [Sq]Mahalanobis and the `CorrDist` metrics. We could shorten the colwise benchmark to those that have a specialized method. Similarly for `pairwise`: the "competitor" doesn't use views. Alternatively, we could include the views in the simple loop competitors, and showcase the results for the specialized BLAS-based methods only?

Closes #204, closes #206.