### PR TITLE
Allow unitful data points

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ julia = "1"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["OffsetArrays", "Random", "Test"]
+test = ["OffsetArrays", "Random", "Test", "Unitful"]

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -11,34 +11,27 @@ The computed distance has the unit of the radius.
 struct Haversine{T} <: Metric
     radius::T
 end
-Haversine() = Haversine(Float32(6371000))
+Haversine() = Haversine(Float32(6_371_000))
 
 function (dist::Haversine)(x, y)
     length(x) == length(y) == 2 || haversine_error(dist)
 
-    @inbounds x1, x2 = x
-    @inbounds y1, y2 = y
-    # longitudes
-    Δλ = _deg2rad(y1 - x1)
+    @inbounds λ₁, φ₁ = x
+    @inbounds λ₂, φ₂ = y
 
-    # latitudes
-    φ₁ = _deg2rad(x2)
-    φ₂ = _deg2rad(y2)
-    Δφ = φ₂ - φ₁
+    Δλ = λ₂ - λ₁  # longitudes
+    Δφ = φ₂ - φ₁  # latitudes
 
     # haversine formula
-    a = sin(Δφ/2)^2 + cos(φ₁)*cos(φ₂)*sin(Δλ/2)^2
+    a = sind(Δφ/2)^2 + cosd(φ₁)*cosd(φ₂)*sind(Δλ/2)^2
 
     # distance on the sphere
     2 * dist.radius * asin( min(√a, one(a)) ) # take care of floating point errors
 end
 
-haversine(x, y, radius=Float32(6371000)) = Haversine(radius)(x, y)
+haversine(x, y, radius=Float32(6_371_000)) = Haversine(radius)(x, y)
 
 @noinline haversine_error(dist) = throw(ArgumentError("expected both inputs to have length 2 in $dist distance"))
-
-_deg2rad(x::Real) = deg2rad(x)
-_deg2rad(x::Number) = x # targets unitful numbers
 
 """
     SphericalAngle()

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -2,7 +2,8 @@
     Haversine([radius])
 
 The haversine distance between two locations on a sphere of given `radius`, whose
-default value is 6371000, i.e., the Earth's mean radius in units of meter.
+default value is 6371000, i.e., the Earth's (volumetric) mean radius in units of meter; cf.
+[NASA's Earth Fact Sheet](https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html).
 
 Locations are described with longitude and latitude in degrees.
 The computed distance has the unit of the radius.

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -8,7 +8,7 @@ default value is 6,371,000, i.e., the Earth's (volumetric) mean radius in meters
 Locations are described with longitude and latitude in degrees.
 The computed distance has the unit of the radius.
 """
-struct Haversine{T} <: Metric
+struct Haversine{T<:Number} <: Metric
     radius::T
 end
 Haversine() = Haversine(Float32(6_371_000))
@@ -29,7 +29,7 @@ function (dist::Haversine)(x, y)
     2 * dist.radius * asin( min(√a, one(a)) ) # take care of floating point errors
 end
 
-haversine(x, y, radius=Float32(6_371_000)) = Haversine(radius)(x, y)
+haversine(x, y, radius::Number=Float32(6_371_000)) = Haversine(radius)(x, y)
 
 @noinline haversine_error(dist) = throw(ArgumentError("expected both inputs to have length 2 in $dist distance"))
 

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -1,8 +1,8 @@
 """
-    Haversine([radius])
+    Haversine(radius=6_371_000)
 
 The haversine distance between two locations on a sphere of given `radius`, whose
-default value is 6371000, i.e., the Earth's (volumetric) mean radius in units of meter; cf.
+default value is 6,371,000, i.e., the Earth's (volumetric) mean radius in meters; cf.
 [NASA's Earth Fact Sheet](https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html).
 
 Locations are described with longitude and latitude in degrees.

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -1,14 +1,13 @@
 """
     Haversine([radius])
 
-The haversine distance between two locations on a sphere of given `radius`.
+The haversine distance between two locations on a sphere of given `radius`, whose
+default value is 6371000, i.e., the Earth's mean radius in units of meter.
 
 Locations are described with longitude and latitude in degrees.
-The computed distance has the same units as that of the radius.
-The default value is 6371000 meters, which is the mean volumetric
-radius of Earth (source https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html).
+The computed distance has the unit of the radius.
 """
-struct Haversine{T<:Real} <: Metric
+struct Haversine{T} <: Metric
     radius::T
 end
 Haversine() = Haversine(Float32(6371000))
@@ -19,11 +18,11 @@ function (dist::Haversine)(x, y)
     @inbounds x1, x2 = x
     @inbounds y1, y2 = y
     # longitudes
-    Δλ = deg2rad(y1 - x1)
+    Δλ = _deg2rad(y1 - x1)
 
     # latitudes
-    φ₁ = deg2rad(x2)
-    φ₂ = deg2rad(y2)
+    φ₁ = _deg2rad(x2)
+    φ₂ = _deg2rad(y2)
     Δφ = φ₂ - φ₁
 
     # haversine formula
@@ -33,11 +32,12 @@ function (dist::Haversine)(x, y)
     2 * dist.radius * asin( min(√a, one(a)) ) # take care of floating point errors
 end
 
-haversine(x, y, radius::Real = Float32(6371000)) = Haversine(radius)(x, y)
+haversine(x, y, radius=Float32(6371000)) = Haversine(radius)(x, y)
 
 @noinline haversine_error(dist) = throw(ArgumentError("expected both inputs to have length 2 in $dist distance"))
 
-
+_deg2rad(x::Real) = deg2rad(x)
+_deg2rad(x) = x # targets unitful numbers
 
 """
     SphericalAngle()

--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -38,7 +38,7 @@ haversine(x, y, radius=Float32(6371000)) = Haversine(radius)(x, y)
 @noinline haversine_error(dist) = throw(ArgumentError("expected both inputs to have length 2 in $dist distance"))
 
 _deg2rad(x::Real) = deg2rad(x)
-_deg2rad(x) = x # targets unitful numbers
+_deg2rad(x::Number) = x # targets unitful numbers
 
 """
     SphericalAngle()

--- a/test/F64.jl
+++ b/test/F64.jl
@@ -8,7 +8,7 @@ F64(x::F64) = x
 for op in (:+, :-, :sin, :cos, :asin, :acos)
     @eval Base.$op(a::F64) = F64($op(a.x))
 end
-for op in (:+, :-, :*, :/, isdefined(Base, :atan2) ? :atan2 : :atan)
+for op in (:+, :-, :*, :/, :rem, isdefined(Base, :atan2) ? :atan2 : :atan)
     @eval Base.$op(a::F64, b::F64) = F64($op(a.x, b.x))
 end
 for op in (:zero, :one,)
@@ -47,5 +47,6 @@ Base.convert(::Type{Float64}, a::F64) = a.x
 Base.convert(::Type{F64}, a::T) where {T <: Number} = F64(a)
 
 # conversion
+Base.Float64(a::F64) = Float64(a.x)
 Base.Int64(a::F64) = Int64(a.x)
 Base.Int32(a::F64) = Int32(a.x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using LinearAlgebra
 using OffsetArrays
 using Random
 using Statistics
+using Unitful.DefaultSymbols
 
 @test isempty(detect_ambiguities(Distances))
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -416,6 +416,7 @@ end #testset
         x, y = (1.,-15.625), (-179.,15.625)
         @test haversine(x, y, 6371.) ≈ 20015 atol=1e-1
         @test haversine(x, y) ≈ 20015086 rtol=1e-7
+        @test Haversine()(x, y) ≈ 20015086 rtol=1e-7
         @test haversine(Float32.(x), Float32.(y)) isa Float32
         @test haversine(Iterators.take(x, 2), Iterators.take(y, 2), 6371.) ≈ 20015 atol=1e-1
         @test_throws ArgumentError haversine([0.,-90., 0.25], [0.,90.], 1.)

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -738,6 +738,33 @@ end
     @test bregman(F, ∇, p, q) ≈ ISdist(p, q)
 end
 
+@testset "Unitful vectors" begin
+    x = [1m, 2m, 3m]; y = [2m, 3m, 4m]; w = [1, 1, 1]; p = [2m, 2m, 2m]
+    @test @inferred sqeuclidean(x, y) == 3m^2
+    @test @inferred euclidean(x, y) == sqrt(3)m
+    @test @inferred cityblock(x, y) == 3m
+    @test @inferred totalvariation(x, y) == 1.5m
+    @test @inferred chebyshev(x, y) == 1m
+    @test @inferred minkowski(x, y, 2) == sqrt(3)m
+    @test @inferred jaccard(x, y) == 1 - sum(min.(x, y)) / sum(max.(x, y))
+    @test @inferred braycurtis(x, y) == sum(abs.(x .- y)) / sum(abs.(x .+ y))
+    @test @inferred cosine_dist(x, y) == 1 - dot(x, y) / (norm(x) * norm(y))
+    @test @inferred corr_dist(x, y) == cosine_dist(x .- mean(x), y .- mean(y))
+    @test @inferred chisq_dist(x, y) == sum((x .- y).^2 ./ (x .+ y))
+    @test @inferred spannorm_dist(x, y) === 0m
+    @test @inferred hellinger(x, y) == sqrt(1 - sum(sqrt.(x .* y) / sqrt(sum(x) * sum(y))))
+    @test @inferred meanad(x, y) == 1m
+    @test @inferred msd(x, y) == 1m^2
+    @test @inferred rmsd(x, y) == 1m
+    @test @inferred nrmsd(x, y) == rmsd(x, y) / (maximum(x) - minimum(x))
+    @test @inferred weuclidean(x, y, w) == euclidean(x, y)
+    @test @inferred wsqeuclidean(x, y, w) == sqeuclidean(x, y)
+    @test @inferred wcityblock(x, y, w) == cityblock(x, y)
+    @test @inferred wminkowski(x, y, w, 2) == euclidean(x, y)
+    @test @inferred whamming(x, y, w) == hamming(x, y)
+    @test @inferred peuclidean(x, y, p) == sqrt(3)m
+end
+
 #=
 @testset "zero allocation colwise!" begin
     d = Euclidean()

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -751,7 +751,7 @@ end
     @test @inferred cosine_dist(x, y) == 1 - dot(x, y) / (norm(x) * norm(y))
     @test @inferred corr_dist(x, y) == cosine_dist(x .- mean(x), y .- mean(y))
     @test @inferred chisq_dist(x, y) == sum((x .- y).^2 ./ (x .+ y))
-    @test @inferred spannorm_dist(x, y) === 0m
+    @test @inferred spannorm_dist(x, y) == 0m
     @test @inferred hellinger(x, y) == sqrt(1 - sum(sqrt.(x .* y) / sqrt(sum(x) * sum(y))))
     @test @inferred meanad(x, y) == 1m
     @test @inferred msd(x, y) == 1m^2

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -414,9 +414,13 @@ end #testset
         @test haversine((-180.,0.), (180.,0.), 1.) ≈ 0 atol=1e-10
         @test haversine((0.,-90.),  (0.,90.),  1.) ≈ π atol=1e-10
         x, y = (1.,-15.625), (-179.,15.625)
-        @test haversine(x, y, 6371.) ≈ 20015. atol=1e0
-        @test haversine(Iterators.take(x, 2), Iterators.take(y, 2), 6371.) ≈ 20015. atol=1e0
+        @test haversine(x, y, 6371.) ≈ 20015 atol=1e-1
+        @test haversine(x, y) ≈ 20015086 rtol=1e-7
+        @test haversine(Float32.(x), Float32.(y)) isa Float32
+        @test haversine(Iterators.take(x, 2), Iterators.take(y, 2), 6371.) ≈ 20015 atol=1e-1
         @test_throws ArgumentError haversine([0.,-90., 0.25], [0.,90.], 1.)
+        x, y = (1.0°,-15.625°), (-179.0°,15.625°)
+        @test haversine(x, y, 6371.0km) ≈ 20015km atol=1e-1km
     end
 end
 


### PR DESCRIPTION
Closes #201. Indeed, there is no reason why in general the temporary variable should have the same type/unit as the final result. Funnily, this added flexibility leads to a significant gain in performance in special cases where the types differ:
```julia
julia> using Distances, BenchmarkTools

julia> x = rand(1:5, 100);

julia> y = rand(1:5, 100);

julia> @btime euclidean($x, $y);
  95.578 ns (0 allocations: 0 bytes) # master
  33.965 ns (0 allocations: 0 bytes) # this PR
```
We need to mimick the `result_type` scheme once more, but the added code is not much. Pretty much all the metrics are covered, except those that involve a `log`, the `Mahalanobis` family, `Bregman`. ~~I need to check if `haversine` works with `°`.~~ EDIT: it does now.