### PR TITLE
Import `pairwise` and `pairwise!` from StatsAPI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.10.2"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
 julia = "1"
+StatsAPI = "1"
 
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -2,6 +2,7 @@ module Distances
 
 using LinearAlgebra
 using Statistics
+import StatsAPI: pairwise, pairwise!
 
 export
     # generic types/functions


### PR DESCRIPTION
This will allow StatsBase to define fallback methods
for these without conflicting with Distances.