### PR TITLE
add Vectorization implementation for GPU

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,15 @@ uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 version = "0.10.3"
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
-julia = "1"
+ArrayInterface = "3.1.17"
 StatsAPI = "1"
+julia = "1"
 
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,11 @@ uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 version = "0.10.3"
 
 [deps]
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
-ArrayInterface = "3.1.17"
 StatsAPI = "1"
 julia = "1"
 

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -1,5 +1,6 @@
 module Distances
 
+using ArrayInterface: device, AbstractDevice, GPU
 using LinearAlgebra
 using Statistics
 import StatsAPI: pairwise, pairwise!

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -1,6 +1,5 @@
 module Distances
 
-using ArrayInterface: device, AbstractDevice, GPU
 using LinearAlgebra
 using Statistics
 import StatsAPI: pairwise, pairwise!

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -53,15 +53,14 @@ struct MapReduce1 <: AbstractEvaluateStrategy end
 
 Infer the optimal strategy to evaluate `d(a, b)`.
 
-Two strategies are provided in Distances, take `Euclidean` as an example:
+Currently, two strategies are provided in Distances:
 
 - `Broadcasting`: evaluate each pair by broadcasting, this is usually performant for arrays
   that has slow scalar indexing, e.g., `CUDA.CuArray`. But it introduces an extra memory
   allocation due to large intermediate result. For `Euclidean`, this is almost equivalent
   to `sqrt(sum(abs2, a - b))`. 
 - `MapReduce1`: use a single-thread version of mapreduce. This has minimal memory allocation.
-  For `Euclidean`, this is almost equivalent to
-  `sqrt(mapreduce(ab->abs2(ab[1]-ab[2]), +, zip(a, b); init=0))`.
+  For `Euclidean`, this is almost equivalent to `sqrt(mapreduce((x,y)->abs2(x-y), +, a, b))`.
 
 # Example
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -27,8 +27,8 @@ function test_metricity(dist, x, y, z)
         @test d == evaluate(dist, x, y)
         if d isa Distances.UnionMetrics
             # currently only UnionMetrics supports this strategy trait
-            d_vec = Distances._evaluate(Distances.Vectorization(), dist, x, y, Distances.parameters(dist))
-            d_scalar = Distances._evaluate(Distances.ScalarMapReduce(), dist, x, y, Distances.parameters(dist))
+            d_vec = Distances._evaluate(Distances.Broadcasting(), dist, x, y, Distances.parameters(dist))
+            d_scalar = Distances._evaluate(Distances.MapReduce1(), dist, x, y, Distances.parameters(dist))
             @test d_vec ≈ d_scalar
         end
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -23,7 +23,14 @@ end
 
 function test_metricity(dist, x, y, z)
     @testset "Test metricity of $(typeof(dist))" begin
-        @test dist(x, y) == evaluate(dist, x, y)
+        d = dist(x, y)
+        @test d == evaluate(dist, x, y)
+        if d isa Distances.UnionMetrics
+            # currently only UnionMetrics supports this strategy trait
+            d_vec = Distances._evaluate(Distances.Vectorization(), dist, x, y, Distances.parameters(dist))
+            d_scalar = Distances._evaluate(Distances.ScalarMapReduce(), dist, x, y, Distances.parameters(dist))
+            @test d_vec ≈ d_scalar
+        end
 
         dxy = dist(x, y)
         dxz = dist(x, z)


### PR DESCRIPTION
One might even come up with a threaded `reduce` version for this, but that definitely belongs to future work.

```julia
@time using Distances
# PR: 0.284294 seconds (232.28 k allocations: 14.743 MiB, 30.94% compilation time)
# master: 0.051195 seconds (102.74 k allocations: 6.502 MiB, 85.42% compilation time)
using CUDA

X_cu = CUDA.randn(2^20);
Y_cu = CUDA.randn(2^20);

X = randn(2^20);
Y = randn(2^20);

@btime sqeuclidean($X, $Y)
# PR: 444.933 μs (0 allocations: 0 bytes)
# master: 418.690 μs (0 allocations: 0 bytes)
# almost a benchmark noisy

@btime sqeuclidean($X_cu, $Y_cu)
# GTX 3090
# PR: 51.827 μs (207 allocations: 5.64 KiB)
# master: take decades because of the scalar indexing
```

I did not expose this trait dispatching to the API level because I'm not sure if the user really wants this. Users might only want to control the computational device(e.g., GPU, CPU, CPU threads, CPU distributed) and may not want to control the under the hood implementation details.

---

> from @KristofferC in https://github.com/JuliaStats/Distances.jl/issues/143#issuecomment-522987543
> > Requires.jl makes loading this package 20x slower (#123 (comment)).

I still feel the runtime benefit worths it; not to mention that GPU support is basically unavailable before. Given that a lot of packages depend on `ArrayInterface`, adding this dependency won't add much of the loading time in any real project. (From [juliahub](https://juliahub.com/ui/Packages) results: `ArrayInterface` is depended by 692 packages while `Distances` is defended by 474 packages.)

```julia
julia> @time using ArrayInterface
  0.228708 seconds (224.97 k allocations: 13.884 MiB, 26.09% compilation time)

julia> @time using Distances
  0.014110 seconds (6.62 k allocations: 604.219 KiB)
```

Edit:

> From @nalimilan in https://github.com/JuliaStats/Distances.jl/issues/143#issuecomment-690931697
> > One solution to this would be to choose the best algorithm based on traits like those provided by ArrayInterface.

ArrayInterface requires Julia 1.2. I'll let you guys decide whether 1) we want to instead depend on Requires, or 2) directly bump the Julia lower bound here and drop Julia 1.0 and 1.1 support, or even 3) make a new package DistancesCUDA :(

closes #137