### PR TITLE
Make pairwise(dist, X) compatible with Unitful values

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -200,7 +200,7 @@ function _pairwise!(r::AbstractMatrix, metric::SemiMetric, a)
         r[i, j] = if i > j
             metric(ai, aj)
         elseif i == j
-            0
+            zero(eltype(r))
         else
             r[j, i]
         end
@@ -216,7 +216,7 @@ function _pairwise!(r::AbstractMatrix, metric::SemiMetric, a::AbstractMatrix)
         for i = 1:(j - 1)
             r[i, j] = r[j, i]   # leveraging the symmetry of SemiMetric
         end
-        r[j, j] = 0
+        r[j, j] = zero(eltype(r))
         aj = view(a, :, j)
         for i = (j + 1):n
             r[i, j] = metric(view(a, :, i), aj)


### PR DESCRIPTION
`pairwise(dist, X)` currently doesn't work with Unitful vectors. This fixes it.

MWE:
```julia
julia> using Distances, Unitful.DefaultSymbols

julia> x = [1m, 2m, 3m]; y = [2m, 3m, 4m];

julia> X = [x,y]
2-element Vector{Vector{Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}}:
 [1 m, 2 m, 3 m]
 [2 m, 3 m, 4 m]
```
Before:
```julia
julia> pairwise(Euclidean(), X)
ERROR: DimensionError: m and 0 are not dimensionally compatible.
```
After:
```julia
julia> pairwise(Euclidean(), X)
2×2 Matrix{Unitful.Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}:
     0.0 m  1.73205 m
 1.73205 m      0.0 m
```

Also works with `PeriodicEucliden(w)`.