### PR TITLE
Make `*Mahalanobis` throw

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.5"
+version = "0.11.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/mahalanobis.jl
+++ b/src/mahalanobis.jl
@@ -22,10 +22,9 @@ Mahalanobis{Matrix{Int64}}([1 4 7; 2 5 8; 3 6 9])
 struct Mahalanobis{M<:AbstractMatrix} <: Metric
     qmat::M
     function Mahalanobis(Q::AbstractMatrix; skipchecks::Bool=false)
-        # TODO: turn the warnings into errors in next breaking release
-        ishermitian(Q) || @warn "matrix is not symmetric/Hermitian"
+        ishermitian(Q) || throw(ArgumentError("matrix is not symmetric/Hermitian"))
         if !skipchecks
-            eigmin(Q) ≥ 0 || @warn "matrix is not positive semidefinite"
+            eigmin(Q) ≥ 0 || throw(ArgumentError("matrix is not positive semidefinite"))
         end
         return new{typeof(Q)}(Q)
     end
@@ -53,10 +52,9 @@ SqMahalanobis{Matrix{Int64}}([1 4 7; 2 5 8; 3 6 9])
 struct SqMahalanobis{M<:AbstractMatrix} <: SemiMetric
     qmat::M
     function SqMahalanobis(Q::AbstractMatrix; skipchecks::Bool=false)
-        # TODO: turn the warnings into errors in next breaking release
-        ishermitian(Q) || @warn "matrix is not symmetric/Hermitian"
+        ishermitian(Q) || throw(ArgumentError("matrix is not symmetric/Hermitian"))
         if !skipchecks
-            eigmin(Q) ≥ 0 || @warn "matrix is not positive semidefinite"
+            eigmin(Q) ≥ 0 || throw(ArgumentError("matrix is not positive semidefinite"))
         end
         return new{typeof(Q)}(Q)
     end

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -439,17 +439,13 @@ end
         end
         A = rand(T, length(x), length(x))
         S = A + A' - I
-        # TODO: let Distances.jl throw in next breaking release
-        # @test_throws ArgumentError SqMahalanobis(A)
-        @test_logs (:warn, "matrix is not positive semidefinite") SqMahalanobis(S)
-        # TODO: let Distances.jl throw in next breaking release
-        # @test_throws ArgumentError Mahalanobis(A)
-        @test_logs (:warn, "matrix is not positive semidefinite") Mahalanobis(S)
+        @test_throws ArgumentError SqMahalanobis(A)
+        @test_throws ArgumentError SqMahalanobis(S)
+        @test_throws ArgumentError Mahalanobis(A)
+        @test_throws ArgumentError Mahalanobis(S)
         # test that semiposdef'ness can be overwritten, avoiding all checks
-        @test_logs (:warn, "matrix is not symmetric/Hermitian") SqMahalanobis(A, skipchecks=true)
-        @test SqMahalanobis(A, skipchecks=true) isa SemiMetric
-        @test_logs (:warn, "matrix is not symmetric/Hermitian") Mahalanobis(A, skipchecks=true)
-        @test Mahalanobis(A, skipchecks=true) isa Metric
+        @test_throws ArgumentError SqMahalanobis(A, skipchecks=true)
+        @test_throws ArgumentError Mahalanobis(A, skipchecks=true)
         @test SqMahalanobis(S, skipchecks=true) isa SemiMetric
         @test Mahalanobis(S, skipchecks=true) isa Metric
     end


### PR DESCRIPTION
IIUC, this seems to fix some AD-related issues with the warnings.

It's a bit unfortunate that we ended using `skipchecks` when it's really only one check that we skip, which could be made clear by, say, `skipposdefcheck`, or, assuming that what is skipped is known from the docstring, just, `skip`, or just leave it.

This is breaking, so I bump the minor version.