### PR TITLE
non rectangular periodic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.jl.*.cov
 *.jl.mem
 *.ji
+.vscode/
 benchmark/params.json
 Manifest.toml

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -982,3 +982,11 @@ end
     end
 end
 =#
+
+@testset "periodic - non-rectangular" begin
+    # basis vectors: [10, 10], [0, 10]
+    p = PeriodicEuclidean([10 0.0; 10.0 10.0])  # each column is a basis vector.
+    @test p([10.1, 10.2], [-10.0, 0.0]) ≈ sqrt(0.1^2 + 0.2^2)
+    @test p([9.9, 10.2], [-10.0, 0.0]) ≈ sqrt(0.1^2 + 0.2^2)
+    @test p([9.9, 9.8], [-10.0, 0.0]) ≈ sqrt(0.1^2 + 0.2^2)
+end


### PR DESCRIPTION
In lattices, the periodic boundary condition is non-rectangular in most cases. It can be an arbitrary parallelogon.
It would be nice if the periods can be a matrix.

I am not very familiar with the design pattern of this package, if someone feel the added code is not qualified according to your standard, please feel free to modify this PR. Thanks!

## Example
```julia
julia> using Distances

julia> p = PeriodicEuclidean([10 0.0; 10.0 10.0])
PeriodicEuclidean{Matrix{Float64}}([10.0 0.0; 10.0 10.0])

julia> evaluate(p, [0.1, 0.2], [10.1, 10.3])
0.1000000000000012
```