### PR TITLE
Add weak dependency on ChainRulesCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -8,15 +8,24 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
+[weakdeps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
+[extensions]
+ChainRulesCoreExt = "ChainRulesCore"
+
 [compat]
+ChainRulesCore = "1"
 StatsAPI = "1"
 julia = "1"
 
 [extras]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["OffsetArrays", "Random", "Test", "Unitful"]
+test = ["ChainRulesCore", "ChainRulesTestUtils", "OffsetArrays", "Random", "Test", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,9 @@ ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["ChainRulesCore", "ChainRulesTestUtils", "OffsetArrays", "Random", "SparseArrays", "Test", "Unitful"]
+test = ["ChainRulesCore", "ChainRulesTestUtils", "OffsetArrays", "Random", "SparseArrays", "StableRNGs", "Test", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [extensions]
-ChainRulesCoreExt = "ChainRulesCore"
+DistancesChainRulesCoreExt = "ChainRulesCore"
 
 [compat]
 ChainRulesCore = "1"

--- a/ext/ChainRulesCoreExt.jl
+++ b/ext/ChainRulesCoreExt.jl
@@ -1,0 +1,145 @@
+module ChainRulesCoreExt
+
+using Distances
+
+import ChainRulesCore
+
+const CRC = ChainRulesCore
+
+## SqEuclidean
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, dist::SqEuclidean, x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    Ω = dist(x, y)
+
+    function SqEuclidean_pullback(ΔΩ)
+        x̄ = (2 * CRC.unthunk(ΔΩ)) .* (x .- y)
+        return CRC.NoTangent(), x̄, -x̄
+    end
+
+    return Ω, SqEuclidean_pullback
+end
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, ::typeof(colwise), dist::SqEuclidean, X::AbstractMatrix{<:Real}, Y::AbstractMatrix{<:Real})
+    Ω = colwise(dist, X, Y)
+
+    function colwise_SqEuclidean_pullback(ΔΩ)
+        X̄ = 2 .* CRC.unthunk(ΔΩ)' .* (X .- Y)
+        return CRC.NoTangent(), CRC.NoTangent(), X̄, -X̄
+    end
+
+    return Ω, colwise_SqEuclidean_pullback
+end
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, ::typeof(pairwise), dist::SqEuclidean, X::AbstractMatrix{<:Real}; dims::Union{Nothing,Integer}=nothing)
+    dims = Distances.deprecated_dims(dims)
+    dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
+    Ω = pairwise(dist, X; dims=dims)
+
+    function pairwise_SqEuclidean_X_pullback(ΔΩ)
+        Δ = CRC.unthunk(ΔΩ)
+        A = Δ .+ transpose(Δ)
+        X̄ = if dims == 1
+            2 .* (sum(A; dims=2) .* X .- A * X)
+        else
+            2 .* (X .* sum(A; dims=1) .- X * A)
+        end
+        return CRC.NoTangent(), CRC.NoTangent(), X̄
+    end
+
+    return Ω, pairwise_SqEuclidean_X_pullback
+end
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, ::typeof(pairwise), dist::SqEuclidean, X::AbstractMatrix{<:Real}, Y::AbstractMatrix{<:Real}; dims::Union{Nothing,Integer}=nothing)
+    dims = Distances.deprecated_dims(dims)
+    dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
+    Ω = pairwise(dist, X, Y; dims=dims)
+
+    function pairwise_SqEuclidean_X_Y_pullback(ΔΩ)
+        Δ = CRC.unthunk(ΔΩ)
+        Δt = transpose(Δ)
+        X̄ = if dims == 1
+            2 .* (sum(Δ; dims=2) .* X .- Δ * Y)
+        else
+            2 .* (X .* sum(Δt; dims=1) .- Y * Δt)
+        end
+        Ȳ = if dims == 1
+            2 .* (sum(Δt; dims=2) .* Y .- Δt * X)
+        else
+            2 .* (Y .* sum(Δ; dims=1) .- X * Δ)
+        end
+        return CRC.NoTangent(), CRC.NoTangent(), X̄, Ȳ
+    end
+
+    return Ω, pairwise_SqEuclidean_X_Y_pullback
+end
+
+## Euclidean
+
+_normalize(x::Real, nrm::Real) = iszero(nrm) && !isnan(x) ? one(x / nrm) : x / nrm
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, dist::Euclidean, x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    Ω = dist(x, y)
+
+    function Euclidean_pullback(ΔΩ)
+        x̄ = _normalize(CRC.unthunk(ΔΩ), Ω) .* (x .- y)
+        return CRC.NoTangent(), x̄, -x̄
+    end
+
+    return Ω, Euclidean_pullback
+end
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, ::typeof(colwise), dist::Euclidean, X::AbstractMatrix{<:Real}, Y::AbstractMatrix{<:Real})
+    Ω = colwise(dist, X, Y)
+
+    function colwise_Euclidean_pullback(ΔΩ)
+        X̄ = _normalize.(CRC.unthunk(ΔΩ)', Ω') .* (X .- Y)
+        return CRC.NoTangent(), CRC.NoTangent(), X̄, -X̄
+    end
+
+    return Ω, colwise_Euclidean_pullback
+end
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, ::typeof(pairwise), dist::Euclidean, X::AbstractMatrix{<:Real}; dims::Union{Nothing,Integer}=nothing)
+    dims = Distances.deprecated_dims(dims)
+    dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
+    Ω = pairwise(dist, X; dims=dims)
+
+    function pairwise_Euclidean_X_pullback(ΔΩ)
+        Δ = CRC.unthunk(ΔΩ)
+        A = _normalize.(Δ .+ transpose(Δ), Ω)
+        X̄ = if dims == 1
+            sum(A; dims=2) .* X .- A * X
+        else
+            X .* sum(A; dims=1) .- X * A
+        end
+        return CRC.NoTangent(), CRC.NoTangent(), X̄
+    end
+
+    return Ω, pairwise_Euclidean_X_pullback
+end
+
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, ::typeof(pairwise), dist::Euclidean, X::AbstractMatrix{<:Real}, Y::AbstractMatrix{<:Real}; dims::Union{Nothing,Integer}=nothing)
+    dims = Distances.deprecated_dims(dims)
+    dims in (1, 2) || throw(ArgumentError("dims should be 1 or 2 (got $dims)"))
+    Ω = pairwise(dist, X, Y; dims=dims)
+
+    function pairwise_Euclidean_X_Y_pullback(ΔΩ)
+        Δ = _normalize.(CRC.unthunk(ΔΩ), Ω)
+        Δt = transpose(Δ)
+        X̄ = if dims == 1
+            sum(Δ; dims=2) .* X .- Δ * Y
+        else
+            X .* sum(Δt; dims=1) .- Y * Δt
+        end
+        Ȳ = if dims == 1
+            sum(Δt; dims=2) .* Y .- Δt * X
+        else
+            Y .* sum(Δ; dims=1) .- X * Δ
+        end
+        return CRC.NoTangent(), CRC.NoTangent(), X̄, Ȳ
+    end
+
+    return Ω, pairwise_Euclidean_X_Y_pullback
+end
+
+end # module

--- a/ext/DistancesChainRulesCoreExt.jl
+++ b/ext/DistancesChainRulesCoreExt.jl
@@ -8,7 +8,12 @@ const CRC = ChainRulesCore
 
 ## SqEuclidean
 
-function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode}, dist::SqEuclidean, x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+function CRC.rrule(
+    ::CRC.RuleConfig{>:CRC.HasReverseMode},
+    dist::SqEuclidean,
+    x::AbstractVector{<:Real},
+    y::AbstractVector{<:Real}
+)
     Ω = dist(x, y)
 
     function SqEuclidean_pullback(ΔΩ)

--- a/ext/DistancesChainRulesCoreExt.jl
+++ b/ext/DistancesChainRulesCoreExt.jl
@@ -1,4 +1,4 @@
-module ChainRulesCoreExt
+module DistancesChainRulesCoreExt
 
 using Distances
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,0 +1,45 @@
+using ChainRulesCore
+using ChainRulesTestUtils
+
+@testset "ChainRulesCore extension" begin
+    n = 4
+    x = randn(n)
+    y = randn(n)
+    X = randn(n, 3)
+    Y = randn(n, 3)
+
+    @testset for metric in (SqEuclidean(), Euclidean())
+        @testset "different arguments" begin
+            # Single evaluation
+            test_rrule(metric ⊢ NoTangent(), x, y)
+
+            # Column-wise distance
+            test_rrule(colwise, metric ⊢ NoTangent(), X, Y)
+
+            # Pairwise distances
+            test_rrule(pairwise, metric ⊢ NoTangent(), X)
+            test_rrule(pairwise, metric ⊢ NoTangent(), X; fkwargs=(dims=1,))
+            test_rrule(pairwise, metric ⊢ NoTangent(), X; fkwargs=(dims=2,))
+            test_rrule(pairwise, metric ⊢ NoTangent(), X, Y)
+            test_rrule(pairwise, metric ⊢ NoTangent(), X, Y; fkwargs=(dims=1,))
+            test_rrule(pairwise, metric ⊢ NoTangent(), X, Y; fkwargs=(dims=2,))    
+        end
+
+        # check numerical issues if distances are zero
+        @testset "equal arguments" begin
+            # Single evaluation
+            test_rrule(metric ⊢ NoTangent(), x, x)
+
+            # Column-wise distance
+            test_rrule(colwise, metric ⊢ NoTangent(), X, X)
+
+            # Pairwise distances
+            # Finite differencing yields impressively inaccurate derivatives for `Euclidean`,
+            # see https://github.com/FluxML/Zygote.jl/blob/45bf883491d2b52580d716d577e2fa8577a07230/test/gradcheck.jl#L1206
+            kwargs = metric isa Euclidean ? (rtol = 1e-5,) : ()
+            test_rrule(pairwise, metric ⊢ NoTangent(), X, X; kwargs...)
+            test_rrule(pairwise, metric ⊢ NoTangent(), X, X; fkwargs=(dims=1,), kwargs...)
+            test_rrule(pairwise, metric ⊢ NoTangent(), X, X; fkwargs=(dims=2,), kwargs...)
+        end
+    end
+end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,12 +1,14 @@
 using ChainRulesCore
 using ChainRulesTestUtils
+using StableRNGs
 
 @testset "ChainRulesCore extension" begin
     n = 4
-    x = randn(n)
-    y = randn(n)
-    X = randn(n, 3)
-    Y = randn(n, 3)
+    rng = StableRNG(100)
+    x = randn(rng, n)
+    y = randn(rng, n)
+    X = randn(rng, n, 3)
+    Y = randn(rng, n, 3)
     Xrep = repeat(x, 1, 3)
     Yrep = repeat(y, 1, 3)
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -7,39 +7,38 @@ using ChainRulesTestUtils
     y = randn(n)
     X = randn(n, 3)
     Y = randn(n, 3)
+    Xrep = repeat(x, 1, 3)
+    Yrep = repeat(y, 1, 3)
 
     @testset for metric in (SqEuclidean(), Euclidean())
-        @testset "different arguments" begin
-            # Single evaluation
-            test_rrule(metric ⊢ NoTangent(), x, y)
+        # Single evaluation
+        test_rrule(metric ⊢ NoTangent(), x, y)
+        test_rrule(metric ⊢ NoTangent(), x, x)
 
+        for A in (X, Xrep)
             # Column-wise distance
-            test_rrule(colwise, metric ⊢ NoTangent(), X, Y)
-
-            # Pairwise distances
-            test_rrule(pairwise, metric ⊢ NoTangent(), X)
-            test_rrule(pairwise, metric ⊢ NoTangent(), X; fkwargs=(dims=1,))
-            test_rrule(pairwise, metric ⊢ NoTangent(), X; fkwargs=(dims=2,))
-            test_rrule(pairwise, metric ⊢ NoTangent(), X, Y)
-            test_rrule(pairwise, metric ⊢ NoTangent(), X, Y; fkwargs=(dims=1,))
-            test_rrule(pairwise, metric ⊢ NoTangent(), X, Y; fkwargs=(dims=2,))    
-        end
-
-        # check numerical issues if distances are zero
-        @testset "equal arguments" begin
-            # Single evaluation
-            test_rrule(metric ⊢ NoTangent(), x, x)
-
-            # Column-wise distance
-            test_rrule(colwise, metric ⊢ NoTangent(), X, X)
+            test_rrule(colwise, metric ⊢ NoTangent(), A, A)
 
             # Pairwise distances
             # Finite differencing yields impressively inaccurate derivatives for `Euclidean`,
             # see https://github.com/FluxML/Zygote.jl/blob/45bf883491d2b52580d716d577e2fa8577a07230/test/gradcheck.jl#L1206
-            kwargs = metric isa Euclidean ? (rtol = 1e-4,) : ()
-            test_rrule(pairwise, metric ⊢ NoTangent(), X, X; kwargs...)
-            test_rrule(pairwise, metric ⊢ NoTangent(), X, X; fkwargs=(dims=1,), kwargs...)
-            test_rrule(pairwise, metric ⊢ NoTangent(), X, X; fkwargs=(dims=2,), kwargs...)
+            kwargs = metric isa Euclidean ? (rtol=1e-3, atol=1e-3) : ()
+            test_rrule(pairwise, metric ⊢ NoTangent(), A; kwargs...)
+            test_rrule(pairwise, metric ⊢ NoTangent(), A; fkwargs=(dims=1,), kwargs...)
+            test_rrule(pairwise, metric ⊢ NoTangent(), A; fkwargs=(dims=2,), kwargs...)
+            test_rrule(pairwise, metric ⊢ NoTangent(), A, A; kwargs...)
+            test_rrule(pairwise, metric ⊢ NoTangent(), A, A; fkwargs=(dims=1,), kwargs...)
+            test_rrule(pairwise, metric ⊢ NoTangent(), A, A; fkwargs=(dims=2,), kwargs...)
+
+            for B in (Y, Yrep)
+                # Column-wise distance
+                test_rrule(colwise, metric ⊢ NoTangent(), A, B)
+
+                # Pairwise distances
+                test_rrule(pairwise, metric ⊢ NoTangent(), A, B)
+                test_rrule(pairwise, metric ⊢ NoTangent(), A, B; fkwargs=(dims=1,))
+                test_rrule(pairwise, metric ⊢ NoTangent(), A, B; fkwargs=(dims=2,))
+            end
         end
     end
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -36,7 +36,7 @@ using ChainRulesTestUtils
             # Pairwise distances
             # Finite differencing yields impressively inaccurate derivatives for `Euclidean`,
             # see https://github.com/FluxML/Zygote.jl/blob/45bf883491d2b52580d716d577e2fa8577a07230/test/gradcheck.jl#L1206
-            kwargs = metric isa Euclidean ? (rtol = 1e-5,) : ()
+            kwargs = metric isa Euclidean ? (rtol = 1e-4,) : ()
             test_rrule(pairwise, metric ⊢ NoTangent(), X, X; kwargs...)
             test_rrule(pairwise, metric ⊢ NoTangent(), X, X; fkwargs=(dims=1,), kwargs...)
             test_rrule(pairwise, metric ⊢ NoTangent(), X, X; fkwargs=(dims=2,), kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,8 @@ using Unitful.DefaultSymbols
 
 include("F64.jl")
 include("test_dists.jl")
+
+# Test ChainRules definitions on Julia versions that support weak dependencies
+if isdefined(Base, :get_extension)
+    include("chainrules.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ include("F64.jl")
 include("test_dists.jl")
 
 # Test ChainRules definitions on Julia versions that support weak dependencies
-if isdefined(Base, :get_extension)
+# Support for extensions was added in
+# https://github.com/JuliaLang/julia/commit/93587d7c1015efcd4c5184e9c42684382f1f9ab2
+# https://github.com/JuliaLang/julia/pull/47695 
+if VERSION >= v"1.9.0-alpha1.18"
     include("chainrules.jl")
 end


### PR DESCRIPTION
This PR proposes to add a weak dependency on ChainRulesCore on Julia versions with support for extensions (i.e., Julia >= 1.9).

This would fix https://github.com/JuliaStats/Distances.jl/issues/172 (and https://github.com/FluxML/Zygote.jl/issues/1365) without affecting load and compilation times for users that do not load ChainRulesCore.

The initial set of reverse-mode rules in this PR covers the existing rules in Zygote and hence could replace these in Julia >= 1.9: Zygote could, e.g., wrap the Requires-block for Distances in a `if !isdefined(Base, :get_extension)` conditional.
The implementation in this PR is different from the code in https://github.com/FluxML/Zygote.jl/pull/923 since tests fail with the rules in the Zygote PR (e.g., due to type inference issues).
The rules in this PR are also all explicit and do not call back into the AD system, in contrast to the current implementation in Zygote.

IMO there are two main motivations for moving the rules to Distances.jl: It allows other ChainRules-compatible AD systems to use them as well without having to depend on Zygote and it fixes precompilation issues reported in https://github.com/FluxML/Zygote.jl/issues/1365. The second point could be fixed also by making Distances a weak dependency of Zygote but that would not solve the first problem.

I know that maintainers of Distances have tried to keep the package lightweight and to not add any dependencies that would increase load times. However, I think the [support for weak dependencies in Pkg](https://pkgdocs.julialang.org/dev/creating-packages/#Weak-dependencies) addresses these concerns. In a few other packages ChainRules-definitions were already moved to extensions recently, e.g., https://github.com/JuliaMath/ChangesOfVariables.jl/pull/12 and https://github.com/JuliaStats/LogExpFunctions.jl/pull/62.