### PR TITLE
fix `_bhattacharyya_coeff` signature type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bhattacharyya.jl
+++ b/src/bhattacharyya.jl
@@ -50,7 +50,7 @@ end
     return sqab, asum, bsum
 end
 
-@inline function _bhattacharyya_coeff(a::SparseVectorUnion{<:Number}, b::SparseVectorUnion{<:Number})
+@inline function _bhattacharyya_coeff(a::SparseVectorUnion, b::SparseVectorUnion)
     anzind = nonzeroinds(a)
     bnzind = nonzeroinds(b)
     anzval = nonzeros(a)


### PR DESCRIPTION
After JuliaSparse/SparseArrays.jl/#355, `SparseArrays.SparseVectorUnion` is no longer `UnionAll`.