### PR TITLE
Fix promotion of F64, add compat bounds for stdlibs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.10"
+version = "0.10.11"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -18,6 +18,9 @@ DistancesSparseArraysExt = "SparseArrays"
 
 [compat]
 ChainRulesCore = "1"
+LinearAlgebra = "1"
+SparseArrays = "1"
+Statistics = "1"
 StatsAPI = "1"
 julia = "1"
 

--- a/test/F64.jl
+++ b/test/F64.jl
@@ -37,8 +37,8 @@ Base.:<=(a::F64, b::F64) = a.x <= b.x
 Base.eps(::Type{F64}) = eps(Float64)
 
 # promotion
-Base.promote_type(::Type{Float32}, ::Type{F64}) = Float64 # for eig
-Base.promote_type(::Type{Float64}, ::Type{F64}) = Float64 # for vecnorm
+Base.promote_rule(::Type{Float32}, ::Type{F64}) = Float64 # for eig
+Base.promote_rule(::Type{Float64}, ::Type{F64}) = Float64 # for vecnorm
 Base.promote(a::F64, b::T) where {T <: Number} = a, F64(float(b))
 Base.promote(a::T, b::F64) where {T <: Number} = F64(float(a)), b
 


### PR DESCRIPTION
This is the recommended way to define promotion anyway, and this preempts failure related to https://github.com/JuliaLang/julia/pull/52038. Along the way, this also add compat bounds for updatable stdlibs as requested for future Julia versions.