### PR TITLE
RFC Added SkipMissing wrapper metric

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.10.11"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
@@ -19,6 +20,7 @@ DistancesSparseArraysExt = "SparseArrays"
 [compat]
 ChainRulesCore = "1"
 LinearAlgebra = "<0.0.1, 1"
+Missings = "1"
 SparseArrays = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"
 StatsAPI = "1"

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -1,6 +1,7 @@
 module Distances
 
 using LinearAlgebra
+using Missings
 using Statistics: mean
 import StatsAPI: pairwise, pairwise!
 
@@ -116,6 +117,7 @@ include("haversine.jl")
 include("mahalanobis.jl")
 include("bhattacharyya.jl")
 include("bregman.jl")
+include("missing.jl")
 
 include("deprecated.jl")
 

--- a/src/missing.jl
+++ b/src/missing.jl
@@ -1,0 +1,47 @@
+"""
+Exclude any missing indices from being included the wrappped distance metric.
+"""
+struct SkipMissing{D<:PreMetric} <: PreMetric
+    d::D
+end
+
+result_type(dist::SkipMissing, a::Type, b::Type) = result_type(dist.d, a, b)
+
+# Always fallback to the internal metric behaviour
+(dist::SkipMissing)(a, b) = dist.d(a, b)
+
+# Special case vector arguments where we can mask out incomplete cases
+function (dist::SkipMissing)(a::AbstractVector, b::AbstractVector)
+    require_one_based_indexing(a)
+    require_one_based_indexing(b)
+    n = length(a)
+    length(b) == n || throw(DimensionMismatch("a and b have different lengths"))
+
+    mask = BitVector(undef, n)
+    @inbounds for i in 1:n
+        mask[i] = !(ismissing(a[i]) || ismissing(b[i]))
+    end
+
+    # Calling `_evaluate` allows us to also mask metric parameters like weights or periods
+    # I don't think this can be generalized to user defined metric types though without knowing
+    # what the parameters mean.
+    # NTOE: We call disallowmissings to avoid downstream type promotion issues.
+    if dist.d isa UnionMetrics
+        params = parameters(dist.d)
+
+        return _evaluate(
+            dist.d,
+            disallowmissing(view(a, mask)),
+            disallowmissing(view(b, mask)),
+            isnothing(params) ? params : view(params, mask),
+        )
+    else
+        return dist.d(
+            disallowmissing(view(a, mask)),
+            disallowmissing(view(b, mask)),
+        )
+    end
+end
+
+# Convenience function
+skipmissing(dist::PreMetric, args...) = SkipMissing(dist)(args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Distances
 
 using Test
 using LinearAlgebra
+using Missings
 using OffsetArrays
 using Random
 using Statistics
@@ -15,7 +16,7 @@ include("test_dists.jl")
 # Test ChainRules definitions on Julia versions that support weak dependencies
 # Support for extensions was added in
 # https://github.com/JuliaLang/julia/commit/93587d7c1015efcd4c5184e9c42684382f1f9ab2
-# https://github.com/JuliaLang/julia/pull/47695 
+# https://github.com/JuliaLang/julia/pull/47695
 if VERSION >= v"1.9.0-alpha1.18"
     include("chainrules.jl")
 end


### PR DESCRIPTION
A potential solution to https://github.com/JuliaStats/Distances.jl/issues/11

Pros:

- Logic is isolated to a few dozen lines in 1 file
- Independent of distance metric types
- Seems like a pretty common approach elsewhere (ex [scikit learn](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.nan_euclidean_distances.html))
- `skipmissing` already exists in base, so hopefully this approach is relatively intuitive

Cons:

- Performance costs (ie: generates a mask and views on each call)
- Sufficiently different from `Base.skipmissing` that we shouldn't export and could cause confusion?
- Arguably shouldn't be a metric and could probably just loosen other APIs to take a user defined function that calls `Missings.skipmissings`? (ex [NearestNeighbors.jl](https://github.com/KristofferC/NearestNeighbors.jl/blob/master/src/NearestNeighbors.jl#L26C81-L26C81))