### PR TITLE
Add `MinkowskiMetric` abstract type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Distances"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.11"
+version = "0.10.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
 
 **MinkowskiMetric** is an abstract type that encompasses a family of metrics defined by the formula
 
-    d(x, y) = sum((x - y) .^ p) ^ (1 / p)
+    d(x, y) = sum(w .* (x - y) .^ p) ^ (1 / p)
 
-where the `p` parameter defines the metric.
+where the `p` parameter defines the metric and `w` is a potential weight vector (all 1's by default).
 
 This type system has practical significance. For example, when computing pairwise distances
 between a set of vectors, you may only perform computation for half of the pairs, derive the

--- a/README.md
+++ b/README.md
@@ -165,13 +165,19 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
     d(x, x) == 0  for all x
     d(x, y) >= 0  for all x, y
 
-**SemiMetric** is a abstract type that refines **PreMetric**. Formally, a *semi-metric* is a *pre-metric* that is also symmetric, as
+**SemiMetric** is an abstract type that refines **PreMetric**. Formally, a *semi-metric* is a *pre-metric* that is also symmetric, as
 
     d(x, y) == d(y, x)  for all x, y
 
-**Metric** is a abstract type that further refines **SemiMetric**. Formally, a *metric* is a *semi-metric* that also satisfies triangle inequality, as
+**Metric** is an abstract type that further refines **SemiMetric**. Formally, a *metric* is a *semi-metric* that also satisfies triangle inequality, as
 
     d(x, z) <= d(x, y) + d(y, z)  for all x, y, z
+
+**MinkowskiMetric** is an abstract type that encompasses a family of metrics defined by the formula
+
+    d(x, y) = sum((x - y) .^ p) ^ (1 / p)
+
+where the `p` parameter defines the metric.
 
 This type system has practical significance. For example, when computing pairwise distances
 between a set of vectors, you may only perform computation for half of the pairs, derive the

--- a/src/Distances.jl
+++ b/src/Distances.jl
@@ -9,6 +9,7 @@ export
     PreMetric,
     SemiMetric,
     Metric,
+    MinkowskiMetric,
 
     # generic functions
     result_type,

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -21,6 +21,13 @@ abstract type SemiMetric <: PreMetric end
 #
 abstract type Metric <: SemiMetric end
 
+# a minkowski metric is a metric that is defined by the formula:
+#
+#   d(x, y) = sum((x - y) .^ p) ^ (1 / p)
+#
+# where the `p` parameter defines the metric.
+abstract type MinkowskiMetric <: Metric end
+
 evaluate(dist::PreMetric, a, b) = dist(a, b)
 
 # Generic functions

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -22,7 +22,7 @@ abstract type SemiMetric <: PreMetric end
 abstract type Metric <: SemiMetric end
 
 """
-    MinkowskiMetric
+    MinkowskiMetric <: Metric
 
 A Minkowski metric is a metric that is defined by the formula:
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -21,13 +21,6 @@ abstract type SemiMetric <: PreMetric end
 #
 abstract type Metric <: SemiMetric end
 
-# a minkowski metric is a metric that is defined by the formula:
-#
-#   d(x, y) = sum((x - y) .^ p) ^ (1 / p)
-#
-# where the `p` parameter defines the metric.
-abstract type MinkowskiMetric <: Metric end
-
 evaluate(dist::PreMetric, a, b) = dist(a, b)
 
 # Generic functions

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -21,6 +21,29 @@ abstract type SemiMetric <: PreMetric end
 #
 abstract type Metric <: SemiMetric end
 
+"""
+    MinkowskiMetric
+
+A Minkowski metric is a metric that is defined by the formula:
+
+`d(x, y) = sum(w .* (x - y) .^ p) ^ (1 / p)`
+
+where the `p` parameter defines the metric 
+and `w` is a potential weight vector (all 1's by default).
+
+Common Minkowski metrics:
+* `Cityblock`/`WeightedCityblock`: Minkowski metric with `p=1`;
+* `Euclidean`/`WeightedEuclidean`: Minkowski metric with `p=2`;
+* `Chebyshev`: Limit of `d` as `p` approaches infinity;
+* `Minkowski`/`WeightedMinkowski`: generic Minkowski metric for any `p`.
+
+## Notes
+* The difference between `Minkowski`/`WeightedMinkowski` and `MinkowskiMetric` 
+  is that while the first are generic Minkowski metrics, 
+  the second is the parent type of these metrics.
+"""
+abstract type MinkowskiMetric <: Metric end
+
 evaluate(dist::PreMetric, a, b) = dist(a, b)
 
 # Generic functions

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -12,28 +12,7 @@ abstract type UnionSemiMetric <: SemiMetric end
 
 abstract type UnionMetric <: Metric end
 
-"""
-    MinkowskiMetric
-
-A Minkowski metric is a metric that is defined by the formula:
-
-`d(x, y) = sum(w .* (x - y) .^ p) ^ (1 / p)`
-
-where the `p` parameter defines the metric 
-and `w` is a potential weight vector (all 1's by default).
-
-Common Minkowski metrics:
-* `Cityblock`/`WeightedCityblock`: Minkowski metric with `p=1`;
-* `Euclidean`/`WeightedEuclidean`: Minkowski metric with `p=2`;
-* `Chebyshev`: Limit of `d` as `p` approaches infinity;
-* `Minkowski`/`WeightedMinkowski`: generic Minkowski metric for any `p`.
-
-## Notes
-* The difference between `Minkowski`/`WeightedMinkowski` and `MinkowskiMetric` 
-  is that while the first are generic Minkowski metrics, 
-  the second is the parent type of these metrics.
-"""
-abstract type MinkowskiMetric <: UnionMetric end
+abstract type UnionMinkowskiMetric <: MinkowskiMetric end
 
 ###########################################################
 #
@@ -41,7 +20,7 @@ abstract type MinkowskiMetric <: UnionMetric end
 #
 ###########################################################
 
-struct Euclidean <: MinkowskiMetric
+struct Euclidean <: UnionMinkowskiMetric
     thresh::Float64
 end
 
@@ -75,7 +54,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
 """
 Euclidean() = Euclidean(0)
 
-struct WeightedEuclidean{W} <: MinkowskiMetric
+struct WeightedEuclidean{W} <: UnionMinkowskiMetric
     weights::W
 end
 
@@ -117,10 +96,10 @@ struct WeightedSqEuclidean{W} <: UnionSemiMetric
     weights::W
 end
 
-struct Chebyshev <: MinkowskiMetric end
+struct Chebyshev <: UnionMinkowskiMetric end
 
-struct Cityblock <: MinkowskiMetric end
-struct WeightedCityblock{W} <: MinkowskiMetric
+struct Cityblock <: UnionMinkowskiMetric end
+struct WeightedCityblock{W} <: UnionMinkowskiMetric
     weights::W
 end
 
@@ -128,10 +107,10 @@ struct TotalVariation <: UnionMetric end
 struct Jaccard <: UnionMetric end
 struct RogersTanimoto <: UnionMetric end
 
-struct Minkowski{T <: Real} <: MinkowskiMetric
+struct Minkowski{T <: Real} <: UnionMinkowskiMetric
     p::T
 end
-struct WeightedMinkowski{W,T <: Real} <: MinkowskiMetric
+struct WeightedMinkowski{W,T <: Real} <: UnionMinkowskiMetric
     weights::W
     p::T
 end
@@ -220,7 +199,7 @@ struct NormRMSDeviation <: PreMetric end
 # Union types
 const metrics = (Euclidean,SqEuclidean,PeriodicEuclidean,Chebyshev,Cityblock,TotalVariation,Minkowski,Hamming,Jaccard,RogersTanimoto,CosineDist,ChiSqDist,KLDivergence,RenyiDivergence,BrayCurtis,JSDivergence,SpanNormDist,GenKLDivergence)
 const weightedmetrics = (WeightedEuclidean,WeightedSqEuclidean,WeightedCityblock,WeightedMinkowski,WeightedHamming)
-const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric}
+const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric,UnionMinkowskiMetric}
 
 ###########################################################
 #
@@ -231,6 +210,7 @@ const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric}
 parameters(::UnionPreMetric) = nothing
 parameters(::UnionSemiMetric) = nothing
 parameters(::UnionMetric) = nothing
+parameters(::UnionMinkowskiMetric) = nothing
 parameters(d::PeriodicEuclidean) = d.periods
 for dist in weightedmetrics
     @eval parameters(d::$dist) = d.weights

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -12,12 +12,27 @@ abstract type UnionSemiMetric <: SemiMetric end
 
 abstract type UnionMetric <: Metric end
 
-# a minkowski metric is a metric that is defined by the formula:
-#
-#   d(x, y) = sum(w .* (x - y) .^ p) ^ (1 / p)
-#
-# where the `p` parameter defines the metric 
-# and `w` is a potential weight vector (all 1's by default).
+"""
+    MinkowskiMetric
+
+A Minkowski metric is a metric that is defined by the formula:
+
+`d(x, y) = sum(w .* (x - y) .^ p) ^ (1 / p)`
+
+where the `p` parameter defines the metric 
+and `w` is a potential weight vector (all 1's by default).
+
+Common Minkowski metrics:
+* `Cityblock`/`WeightedCityblock`: Minkowski metric with `p=1`;
+* `Euclidean`/`WeightedEuclidean`: Minkowski metric with `p=2`;
+* `Chebyshev`: Limit of `d` as `p` approaches infinity;
+* `Minkowski`/`WeightedMinkowski`: generic Minkowski metric for any `p`.
+
+## Notes
+* The difference between `Minkowski`/`WeightedMinkowski` and `MinkowskiMetric` 
+  is that while the first are generic Minkowski metrics, 
+  the second is the parent type of these metrics.
+"""
 abstract type MinkowskiMetric <: UnionMetric end
 
 ###########################################################

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -12,13 +12,15 @@ abstract type UnionSemiMetric <: SemiMetric end
 
 abstract type UnionMetric <: Metric end
 
+abstract type UnionMinkowskiMetric <: MinkowskiMetric end
+
 ###########################################################
 #
 #   Metric types
 #
 ###########################################################
 
-struct Euclidean <: UnionMetric
+struct Euclidean <: UnionMinkowskiMetric
     thresh::Float64
 end
 
@@ -52,7 +54,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
 """
 Euclidean() = Euclidean(0)
 
-struct WeightedEuclidean{W} <: UnionMetric
+struct WeightedEuclidean{W} <: UnionMinkowskiMetric
     weights::W
 end
 
@@ -94,10 +96,10 @@ struct WeightedSqEuclidean{W} <: UnionSemiMetric
     weights::W
 end
 
-struct Chebyshev <: UnionMetric end
+struct Chebyshev <: UnionMinkowskiMetric end
 
-struct Cityblock <: UnionMetric end
-struct WeightedCityblock{W} <: UnionMetric
+struct Cityblock <: UnionMinkowskiMetric end
+struct WeightedCityblock{W} <: UnionMinkowskiMetric
     weights::W
 end
 
@@ -105,10 +107,10 @@ struct TotalVariation <: UnionMetric end
 struct Jaccard <: UnionMetric end
 struct RogersTanimoto <: UnionMetric end
 
-struct Minkowski{T <: Real} <: UnionMetric
+struct Minkowski{T <: Real} <: UnionMinkowskiMetric
     p::T
 end
-struct WeightedMinkowski{W,T <: Real} <: UnionMetric
+struct WeightedMinkowski{W,T <: Real} <: UnionMinkowskiMetric
     weights::W
     p::T
 end
@@ -197,7 +199,7 @@ struct NormRMSDeviation <: PreMetric end
 # Union types
 const metrics = (Euclidean,SqEuclidean,PeriodicEuclidean,Chebyshev,Cityblock,TotalVariation,Minkowski,Hamming,Jaccard,RogersTanimoto,CosineDist,ChiSqDist,KLDivergence,RenyiDivergence,BrayCurtis,JSDivergence,SpanNormDist,GenKLDivergence)
 const weightedmetrics = (WeightedEuclidean,WeightedSqEuclidean,WeightedCityblock,WeightedMinkowski,WeightedHamming)
-const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric}
+const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric,UnionMinkowskiMetric}
 
 ###########################################################
 #
@@ -208,6 +210,7 @@ const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric}
 parameters(::UnionPreMetric) = nothing
 parameters(::UnionSemiMetric) = nothing
 parameters(::UnionMetric) = nothing
+parameters(::UnionMinkowskiMetric) = nothing
 parameters(d::PeriodicEuclidean) = d.periods
 for dist in weightedmetrics
     @eval parameters(d::$dist) = d.weights

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -14,9 +14,10 @@ abstract type UnionMetric <: Metric end
 
 # a minkowski metric is a metric that is defined by the formula:
 #
-#   d(x, y) = sum((x - y) .^ p) ^ (1 / p)
+#   d(x, y) = sum(w .* (x - y) .^ p) ^ (1 / p)
 #
-# where the `p` parameter defines the metric.
+# where the `p` parameter defines the metric 
+# and `w` is a potential weight vector (all 1's by default).
 abstract type MinkowskiMetric <: UnionMetric end
 
 ###########################################################

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -12,7 +12,12 @@ abstract type UnionSemiMetric <: SemiMetric end
 
 abstract type UnionMetric <: Metric end
 
-abstract type UnionMinkowskiMetric <: MinkowskiMetric end
+# a minkowski metric is a metric that is defined by the formula:
+#
+#   d(x, y) = sum((x - y) .^ p) ^ (1 / p)
+#
+# where the `p` parameter defines the metric.
+abstract type MinkowskiMetric <: UnionMetric end
 
 ###########################################################
 #
@@ -20,7 +25,7 @@ abstract type UnionMinkowskiMetric <: MinkowskiMetric end
 #
 ###########################################################
 
-struct Euclidean <: UnionMinkowskiMetric
+struct Euclidean <: MinkowskiMetric
     thresh::Float64
 end
 
@@ -54,7 +59,7 @@ julia> pairwise(Euclidean(1e-12), x, x)
 """
 Euclidean() = Euclidean(0)
 
-struct WeightedEuclidean{W} <: UnionMinkowskiMetric
+struct WeightedEuclidean{W} <: MinkowskiMetric
     weights::W
 end
 
@@ -96,10 +101,10 @@ struct WeightedSqEuclidean{W} <: UnionSemiMetric
     weights::W
 end
 
-struct Chebyshev <: UnionMinkowskiMetric end
+struct Chebyshev <: MinkowskiMetric end
 
-struct Cityblock <: UnionMinkowskiMetric end
-struct WeightedCityblock{W} <: UnionMinkowskiMetric
+struct Cityblock <: MinkowskiMetric end
+struct WeightedCityblock{W} <: MinkowskiMetric
     weights::W
 end
 
@@ -107,10 +112,10 @@ struct TotalVariation <: UnionMetric end
 struct Jaccard <: UnionMetric end
 struct RogersTanimoto <: UnionMetric end
 
-struct Minkowski{T <: Real} <: UnionMinkowskiMetric
+struct Minkowski{T <: Real} <: MinkowskiMetric
     p::T
 end
-struct WeightedMinkowski{W,T <: Real} <: UnionMinkowskiMetric
+struct WeightedMinkowski{W,T <: Real} <: MinkowskiMetric
     weights::W
     p::T
 end
@@ -199,7 +204,7 @@ struct NormRMSDeviation <: PreMetric end
 # Union types
 const metrics = (Euclidean,SqEuclidean,PeriodicEuclidean,Chebyshev,Cityblock,TotalVariation,Minkowski,Hamming,Jaccard,RogersTanimoto,CosineDist,ChiSqDist,KLDivergence,RenyiDivergence,BrayCurtis,JSDivergence,SpanNormDist,GenKLDivergence)
 const weightedmetrics = (WeightedEuclidean,WeightedSqEuclidean,WeightedCityblock,WeightedMinkowski,WeightedHamming)
-const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric,UnionMinkowskiMetric}
+const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric}
 
 ###########################################################
 #
@@ -210,7 +215,6 @@ const UnionMetrics = Union{UnionPreMetric,UnionSemiMetric,UnionMetric,UnionMinko
 parameters(::UnionPreMetric) = nothing
 parameters(::UnionSemiMetric) = nothing
 parameters(::UnionMetric) = nothing
-parameters(::UnionMinkowskiMetric) = nothing
 parameters(d::PeriodicEuclidean) = d.periods
 for dist in weightedmetrics
     @eval parameters(d::$dist) = d.weights


### PR DESCRIPTION
This new type will allow third-party packages to differentiate Minkowski metrics at the type level. It will also allow third-party packages to implement their own Minkowski metrics.

A practical example of a package that could use this new abstract type is NearestNeighbors.jl, which is currently using a union type for this purpose:

https://github.com/KristofferC/NearestNeighbors.jl/blob/master/src/kd_tree.jl#L1

With this new type NearestNeighbors.j could use Minkowski metrics defined in any package.