### PR TITLE
Use `hypot` in haversine calculation for more floating-point safety

### DIFF
--- a/src/haversine.jl
+++ b/src/haversine.jl
@@ -24,10 +24,11 @@ function (dist::Haversine)(x, y)
     Δφ = φ₂ - φ₁  # latitudes
 
     # haversine formula
-    a = sind(Δφ/2)^2 + cosd(φ₁)*cosd(φ₂)*sind(Δλ/2)^2
+    # hypot(x, y) is equivalent to sqrt(x^2 + y^2)
+    sqrt_a = hypot(sind(Δφ/2), cosd(φ₁)*cosd(φ₂)*sind(Δλ/2))
 
     # distance on the sphere
-    2 * (dist.radius * asin( min(√a, one(a)) )) # take care of floating point errors
+    2 * (dist.radius * asin( min(sqrt_a, one(sqrt_a)) )) # take care of floating point errors
 end
 
 haversine(x, y, radius::Number=6_371_000) = Haversine(radius)(x, y)


### PR DESCRIPTION
hypot(x, y) is sqrt(x^2 + y^2) but implemented in an error-corrected way.  It is a bit slower though, so depends on the tradeoff you want to make.  Feel free to accept or reject.