### PR TITLE
Add link to TableDistances.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 A Julia package for evaluating distances (metrics) between vectors.
 
 This package also provides optimized functions to compute column-wise and
-pairwise distances, which are often substantially faster than a straightforward
-loop implementation. (See the benchmark section below for details).
+pairwise distances with matrices (i.e., 2D arrays), which are often
+substantially faster than a straightforward loop implementation.
+(See the benchmark section below for details).
+
+For distances between tables with heterogeneous columns, please
+check [TableDistances.jl](https://github.com/JuliaML/TableDistances.jl).
 
 ## Supported distances
 


### PR DESCRIPTION
In  machine learning, distances are often computed with heterogeneous tables (e.g., kernel methods). This link can save users of Distances.jl a ton of time reinventing the wheel.